### PR TITLE
Improved docker discovery tls key/cert check

### DIFF
--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -197,10 +197,10 @@ protocol = "udp"
 #  docker_container_label = "proxied=true"   # (optional) Label to filter containers
 #  docker_container_host_env_var = ""        # (optional) Take container host from container env variable
 #
-#  docker_tls_enabled = false                # (optional) enable client tls auth
-#  docker_tls_cert_path = '/path/to/cert.pem'
-#  docker_tls_key_path = '/path/to/key.pem'
-#  docker_tls_cacert_path = '/path/to/cacert.pem'
+#  docker_tls_enabled = false                 # (optional) enable client tls auth
+#  docker_tls_cert_path = '/path/to/cert.pem' # (optional) key and cert should be specified together, or both left not specified
+#  docker_tls_key_path = '/path/to/key.pem'   # (optional)
+#  docker_tls_cacert_path = '/path/to/cacert.pem' # (optional) if not specified, docker endpoint tls verification will be skipped (insecure!)
 #
 #  # -- json -- #
 #  kind = "json"

--- a/src/discovery/docker.go
+++ b/src/discovery/docker.go
@@ -51,9 +51,10 @@ func dockerFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 
 	if cfg.DockerTlsEnabled {
 
-		// Added because docker client error very scant
-		if cfg.DockerTlsCacertPath == "" || cfg.DockerTlsCertPath == "" || cfg.DockerTlsKeyPath == "" {
-			return nil, errors.New("Missing keys or certificates required for TLS")
+		// Client cert and key files should be specified together (or both not specified)
+		// Ca cert may be not specified, so not checked here
+		if (cfg.DockerTlsCertPath == "") != (cfg.DockerTlsKeyPath == "") {
+			return nil, errors.New("Missing key or certificate required for TLS client validation")
 		}
 
 		client, err = docker.NewTLSClient(cfg.DockerEndpoint, cfg.DockerTlsCertPath, cfg.DockerTlsKeyPath, cfg.DockerTlsCacertPath)


### PR DESCRIPTION
Make it is possible to omit cacert and client cert/key pair.