### PR TITLE
LXD backend discovery support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Illarion Kovalchuk <illarion.kovalchuk@gmail.com>
 Ievgen Ponomarenko <kikomdev@gmail.com>
 Nick Doikov <Nick.Doikov@gmail.com>
 Seua Polyakov <ctrlok@gmail.com>
+Joe Topjian <joe@topjian.net>

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,12 @@ deps: clean-deps
 	github.com/gin-gonic/gin \
 	github.com/hashicorp/consul/api \
 	github.com/spf13/cobra \
-	github.com/gin-contrib/cors \
 	github.com/Microsoft/go-winio \
 	golang.org/x/sys/windows \
-	github.com/inconshreveable/mousetrap
+	github.com/inconshreveable/mousetrap \
+	github.com/gin-contrib/cors \
+	github.com/lxc/lxd \
+	github.com/jtopjian/lxdhelpers
 
 clean-dist:
 	rm -rf ./dist/${VERSION}
@@ -78,7 +80,7 @@ clean-dist:
 dist:
 	@# For linux 386 when building on linux amd64 you'll need 'libc6-dev-i386' package
 	@echo Building dist
-	
+
 	@#             os    arch  cgo ext
 	@for arch in "linux   386  1      "  "linux   amd64 1      "  \
 				 "windows 386  0 .exe "  "windows amd64 0 .exe "  \
@@ -98,11 +100,11 @@ dist:
 	  fi \
 	done 
 
-build-container-latest: build 
+build-container-latest: build
 	@echo Building docker container LATEST
 	docker build -t yyyar/gobetween .
 
-build-container-tagged: build 
+build-container-tagged: build
 	@echo Building docker container ${VERSION}
 	docker build -t yyyar/gobetween:${VERSION} .
 

--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -62,7 +62,6 @@ bind = "localhost:3000"
       "localhost:8001"
   ]
 
-
 # ---------- udp example ----------- #
 
 [servers.udpsample]
@@ -236,3 +235,24 @@ protocol = "udp"
 #  consul_tls_key_path = "/path/to/key.pem"
 #  consul_tls_cacert_path = "/path/to/cacert.pem"
 #
+#  # -- lxd -- #
+#  kind = "lxd"
+#  lxd_server_address = "unix:///var/lib/lxd/unix.socket"   # (required) Address of the LXD server. Either unix://<path> or https://<addr>:port
+#  lxd_server_remote_name = ""                              # (optional) Name of the LXD server
+#  lxd_server_remote_password = ""                          # (optional) Password to the remote LXD server. Only used when address scheme is https
+#
+#  lxd_config_directory = "~/.config/lxd"                   # (optional) Directory where LXD server info and certificates are stored
+#  lxd_generate_client_certs = false                        # (optional) Generate client SSL certificates for gobetween if not previously generated. Only used when scheme is https
+#  lxd_accept_server_cert = false                           # (optional) Accept the LXD server certificate. Only used when scheme is https
+#
+#  lxd_container_label_key = "user.label"                   # (optional) Filter containers that have specified setting
+#  lxd_container_label_value = "foo"                        # (optional) Filter continers that have specified value of 'lxd_container_label_key' setting
+#
+#  lxd_container_port = 0                                   # (required) Port of container to use
+#  lxd_container_port_key = "user.gobetween.port"           # (optional) Container setting key that specifies the port.
+#
+#  lxd_container_interface = "eth0"                         # (optional) Interface of container to use
+#  lxd_container_interface_key = "user.gobetween.interface" # (optional) Container setting that specifies the interface.
+#
+#  lxd_container_sni_key = ""                               # (optional) Container setting that specifies the sni name of the container.
+#  lxd_container_address_type = "IPv4"                      # (optional) Container setting that specifies whether to use an IPv4 or IPv6 address. Valid options are IPv4 or IPv6.

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -32,7 +32,7 @@ type ApiConfig struct {
 	Bind      string              `toml:"bind" json:"bind"`
 	BasicAuth *ApiBasicAuthConfig `toml:"basic_auth" json:"basic_auth"`
 	Tls       *ApiTlsConfig       `toml:"tls" json:"tls"`
-	Cors      bool		      `toml:"cors" json:"cors"`
+	Cors      bool                `toml:"cors" json:"cors"`
 }
 
 /**
@@ -170,6 +170,7 @@ type DiscoveryConfig struct {
 	*ExecDiscoveryConfig
 	*PlaintextDiscoveryConfig
 	*ConsulDiscoveryConfig
+	*LXDDiscoveryConfig
 }
 
 type StaticDiscoveryConfig struct {
@@ -226,6 +227,28 @@ type ConsulDiscoveryConfig struct {
 	ConsulTlsCertPath   string `toml:"consul_tls_cert_path" json:"consul_tls_cert_path"`
 	ConsulTlsKeyPath    string `toml:"consul_tls_key_path" json:"consul_tls_key_path"`
 	ConsulTlsCacertPath string `toml:"consul_tls_cacert_path" json:"consul_tls_cacert_path"`
+}
+
+type LXDDiscoveryConfig struct {
+	LXDServerAddress        string `toml:"lxd_server_address" json:"lxd_server_address"`
+	LXDServerRemoteName     string `toml:"lxd_server_remote_name" json:"lxd_server_remote_name"`
+	LXDServerRemotePassword string `toml:"lxd_server_remote_password" json:"lxd_server_remote_password"`
+
+	LXDConfigDirectory     string `toml:"lxd_config_directory" json:"lxd_config_directory"`
+	LXDGenerateClientCerts bool   `toml:"lxd_generate_client_certs" json:"lxd_generate_client_certs"`
+	LXDAcceptServerCert    bool   `toml:"lxd_accept_server_cert" json:"lxd_accept_server_cert"`
+
+	LXDContainerLabelKey   string `toml:"lxd_container_label_key" json:"lxd_container_label_key"`
+	LXDContainerLabelValue string `toml:"lxd_container_label_value" json:"lxd_container_label_value"`
+
+	LXDContainerPort    int    `toml:"lxd_container_port" json:"lxd_container_port"`
+	LXDContainerPortKey string `toml:"lxd_container_port_key" json:"lxd_container_port_key"`
+
+	LXDContainerInterface    string `toml:"lxd_container_interface" json:"lxd_container_interface"`
+	LXDContainerInterfaceKey string `toml:"lxd_container_interface_key" json:"lxd_container_interface_key"`
+
+	LXDContainerSNIKey      string `toml:"lxd_container_sni_key" json:"lxd_container_sni_key"`
+	LXDContainerAddressType string `toml:"lxd_container_address_type" json:"lxd_container_address_type"`
 }
 
 /**

--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -29,6 +29,7 @@ func init() {
 	registry["exec"] = NewExecDiscovery
 	registry["plaintext"] = NewPlaintextDiscovery
 	registry["consul"] = NewConsulDiscovery
+	registry["lxd"] = NewLXDDiscovery
 }
 
 /**

--- a/src/discovery/lxd.go
+++ b/src/discovery/lxd.go
@@ -1,0 +1,291 @@
+/**
+ * lxd.go - LXD API discovery implementation
+ *
+ * @author Joe Topjian <joe@topjian.net>
+ */
+
+package discovery
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"../config"
+	"../core"
+	"../logging"
+	"../utils"
+
+	"github.com/jtopjian/lxdhelpers"
+
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
+)
+
+const (
+	lxdRetryWaitDuration = 2 * time.Second
+	lxdTimeout           = 5 * time.Second
+)
+
+/**
+ * Create new Discovery with LXD fetch func
+ */
+func NewLXDDiscovery(cfg config.DiscoveryConfig) interface{} {
+
+	d := Discovery{
+		opts:  DiscoveryOpts{lxdRetryWaitDuration},
+		fetch: lxdFetch,
+		cfg:   cfg,
+	}
+
+	return &d
+}
+
+/**
+ * Fetch backends from LXD API
+ */
+func lxdFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
+	log := logging.For("lxdFetch")
+
+	/* Get an LXD client */
+	client, err := lxdBuildClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	/* Set the timeout for the client */
+	client.Http.Timeout = utils.ParseDurationOrDefault(cfg.Timeout, lxdTimeout)
+
+	log.Debug("Fetching containers from ", client.Config.Remotes[cfg.LXDServerRemoteName].Addr)
+
+	/* Create backends from response */
+	backends := []core.Backend{}
+
+	/* Fetch containers */
+	containers, err := client.ListContainers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range containers {
+
+		/* Ignore containers that aren't running */
+		if container.Status != "Running" {
+			continue
+		}
+
+		/* Ignore continers if not match label key and value */
+		if cfg.LXDContainerLabelKey != "" {
+
+			actualLabelValue, ok := container.Config[cfg.LXDContainerLabelKey]
+			if !ok {
+				continue
+			}
+
+			if cfg.LXDContainerLabelValue != "" && actualLabelValue != cfg.LXDContainerLabelValue {
+				continue
+			}
+		}
+
+		/* Try get container port either from label, or from discovery config */
+		port := fmt.Sprintf("%v", cfg.LXDContainerPort)
+
+		if cfg.LXDContainerPortKey != "" {
+			if p, ok := container.Config[cfg.LXDContainerPortKey]; ok {
+				port = p
+			}
+		}
+
+		if port == "" {
+			log.Warn(fmt.Sprintf("Port is not found in neither in lxd_container_port config not in %s label for %s. Skipping",
+				cfg.LXDContainerPortKey, container.Name))
+			continue
+		}
+
+		/* iface is the container interface to get an IP address. */
+		/* This isn't exposed by the LXD API, and containers can have multiple interfaces, */
+		iface := cfg.LXDContainerInterface
+		if v, ok := container.Config[cfg.LXDContainerInterfaceKey]; ok {
+			iface = v
+		}
+
+		ip := ""
+		if ip, err = lxdDetermineContainerIP(client, container.Name, iface, cfg.LXDContainerAddressType); err != nil {
+			log.Error(fmt.Sprintf("Can't determine %s container ip address: %s. Skipping", container.Name, err))
+			continue
+		}
+
+		sni := ""
+		if v, ok := container.Config[cfg.LXDContainerSNIKey]; ok {
+			sni = v
+		}
+
+		backends = append(backends, core.Backend{
+			Target: core.Target{
+				Host: ip,
+				Port: port,
+			},
+			Priority: 1,
+			Weight:   1,
+			Stats: core.BackendStats{
+				Live: true,
+			},
+			Sni: sni,
+		})
+	}
+
+	return &backends, nil
+}
+
+/**
+ * Create new LXD Client
+ */
+func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
+	log := logging.For("lxdBuildClient")
+
+	/* Make a client to pass around */
+	var client *lxd.Client
+
+	/* Build a configuration with the requested options */
+	lxdConfig, err := lxdBuildConfig(cfg)
+	if err != nil {
+		return client, err
+	}
+
+	if strings.HasPrefix(cfg.LXDServerAddress, "https:") {
+
+		/* Validate or generate certificates on the client side (gobetween) */
+		if err := lxdhelpers.ValidateClientCertificates(lxdConfig, cfg.LXDGenerateClientCerts); err != nil {
+			return nil, err
+		}
+
+		/* Validate or accept certificates on the server side (LXD) */
+		serverCertf := lxdConfig.ServerCertPath(cfg.LXDServerRemoteName)
+		if !shared.PathExists(serverCertf) {
+
+			/* If the server certificate was not found, either gobetween and the LXD server are set
+			 * up for PKI, or gobetween must authenticate with the LXD server and accept its server
+			 * certificate.
+			 *
+			 * First, create a simple LXD client
+			 */
+			client, err = lxd.NewClient(&lxdConfig, cfg.LXDServerRemoteName)
+			if err != nil {
+				return nil, err
+			}
+
+			/* Next, check if the client is able to communicate with the LXD server. If it can,
+			 * this means that gobetween and the LXD server are configured with PKI certificates
+			 * from a private CA.
+			 *
+			 * But if there's an error, then gobetween will try to download the server's cert.
+			 */
+			if _, err := client.GetServerConfig(); err != nil {
+				if cfg.LXDAcceptServerCert {
+					var err error
+					client, err = lxdhelpers.GetRemoteCertificate(client, cfg.LXDServerRemoteName)
+					if err != nil {
+						return nil, fmt.Errorf("Could not add the LXD server: ", err)
+					}
+				} else {
+					err := fmt.Errorf("Unable to communicate with LXD server. Either set " +
+						"lxd_accept_server_cert to true or add the LXD server out of " +
+						"band of gobetween and try again.")
+					return nil, err
+				}
+			}
+
+			/*
+			 * Finally, check and see if gobetween needs to authenticate with the LXD server.
+			 * Authentication happens only once. After that, gobetween will be a trusted client
+			 * as long as the exchanged certificates to not change.
+			 *
+			 * Authentication must happen even if PKI is in use.
+			 */
+			log.Info("Attempting to authenticate")
+			err = lxdhelpers.ValidateRemoteConnection(client, cfg.LXDServerRemoteName, cfg.LXDServerRemotePassword)
+			if err != nil {
+				log.Info("Authentication unsuccessful")
+				return nil, err
+			}
+
+			log.Info("Authentication successful")
+		}
+	}
+
+	/* Build a new client */
+	client, err = lxd.NewClient(&lxdConfig, cfg.LXDServerRemoteName)
+	if err != nil {
+		return nil, err
+	}
+
+	/* Validate the client config and connectivity */
+	if _, err := client.GetServerConfig(); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+/**
+ * Create LXD Client Config
+ */
+func lxdBuildConfig(cfg config.DiscoveryConfig) (lxd.Config, error) {
+	log := logging.For("lxdBuildConfig")
+
+	log.Debug("Using API: ", cfg.LXDServerAddress)
+
+	/* Build an LXD configuration that will connect to the requested LXD server */
+	config := lxd.Config{
+		ConfigDir: cfg.LXDConfigDirectory,
+		Remotes:   make(map[string]lxd.RemoteConfig),
+	}
+	config.Remotes[cfg.LXDServerRemoteName] = lxd.RemoteConfig{Addr: cfg.LXDServerAddress}
+
+	return config, nil
+}
+
+/**
+ * Get container IP address depending on network interface and address type
+ */
+func lxdDetermineContainerIP(client *lxd.Client, container, iface, addrType string) (string, error) {
+	var containerIP string
+
+	/* Convert addrType to inet */
+	var inet string
+	switch addrType {
+	case "IPv4":
+		inet = "inet"
+	case "IPv6":
+		inet = "inet6"
+	}
+
+	cstate, err := client.ContainerState(container)
+	if err != nil {
+		return "", err
+	}
+
+	for i, network := range cstate.Network {
+		if i != iface {
+			continue
+		}
+
+		for _, ip := range network.Addresses {
+			if ip.Family == inet {
+				containerIP = ip.Address
+				break
+			}
+		}
+	}
+
+	/* If IPv6, format correctly */
+	if inet == "inet6" {
+		containerIP = fmt.Sprintf("[%s]", containerIP)
+	}
+
+	if containerIP == "" {
+		return "", fmt.Errorf("Unable to determine IP address for LXD container %s", container)
+	}
+
+	return containerIP, nil
+}


### PR DESCRIPTION
Hello,

I think gobetween would be a great fit for LXD containers, so I made a proof-of-concept discovery. The idea is to configure the LXD discovery like any other discovery mechanism, and then launch an LXD container like so:

```shell
$ lxc launch ubuntu foo --config user.gobetween.label="foo" --config user.gobetween.private_port=80
```

LXD reserves the `user.*` config key for user-specified metadata. The full config reference is [here](https://github.com/lxc/lxd/blob/master/doc/configuration.md)

Right now, discovery is only done on the local server, so only local containers are discovered. However, it could be extended to support remote LXD server(s).

I'm happy to answer any questions about this feature. In addition, I wasn't able to find a doc that lists the requirements for contributing a patch, so please let me know if I need to do anything else.

What I would really like to do is use gobetween to dynamically generate server entries based on containers. This is because LXD does not provide a built-in mechanism to automatically handle external-to-container traffic (similar to publishing a docker port). In effect, gobetween would supply that support. I understand this might be too much of a niche case for gobetween, though. Perhaps a better solution is to write a glue utility that bridges the LXD server and gobetween by using the gobetween REST API rather than have gobetween directly support this.