### PR TITLE
conf directory needs to exist for Docker mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:7
 
+RUN mkdir -p /etc/gobetween/conf
+
 COPY bin/gobetween  /usr/bin/
 
 CMD ["/usr/bin/gobetween", "-c", "/etc/gobetween/conf/gobetween.toml"]


### PR DESCRIPTION
using Docker's volume mounts, the config file can be mounted to "/etc/gobetween/conf/gobetween.toml".

The parent directory needs to exist inside the Docker for this.