### PR TITLE
show version string during startup

### DIFF
--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"../info"
 	"../config"
 	"../core"
 	"../logging"
@@ -37,7 +38,12 @@ var originalCfg config.Config
 func Initialize(cfg config.Config) {
 
 	log := logging.For("manager")
+	var versionStr string
+	
+	versionStr = "gobetween version [" + info.Version + "]"
+	
 	log.Info("Initializing...")
+	log.Info(versionStr)
 
 	originalCfg = cfg
 


### PR DESCRIPTION
Apologies in advance for any programming boo-boos like variable name conventions.

I built and ran this on my dev box and got the output.
```
[INFO ] (manager): gobetween version [0.5.0+snapshot]
```
Hope this is fine.

edit: The use case is that when I look at logs later to see if gobetween had ever restarted, I can grep for a specific message to assist in debugging.

Regards,
Shantanu