### PR TITLE
Two small fixes for LXD

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -242,7 +242,6 @@ type LXDDiscoveryConfig struct {
 	LXDContainerLabelKey   string `toml:"lxd_container_label_key" json:"lxd_container_label_key"`
 	LXDContainerLabelValue string `toml:"lxd_container_label_value" json:"lxd_container_label_value"`
 
-	LXDContainerPort    int    `toml:"lxd_container_port" json:"lxd_container_port"`
 	LXDContainerPortKey string `toml:"lxd_container_port_key" json:"lxd_container_port_key"`
 
 	LXDContainerInterface    string `toml:"lxd_container_interface" json:"lxd_container_interface"`

--- a/src/discovery/lxd.go
+++ b/src/discovery/lxd.go
@@ -185,7 +185,7 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 					var err error
 					client, err = lxdhelpers.GetRemoteCertificate(client, cfg.LXDServerRemoteName)
 					if err != nil {
-						return nil, fmt.Errorf("Could not add the LXD server: ", err)
+						return nil, fmt.Errorf("Could not add the LXD server: %s", err)
 					}
 				} else {
 					err := fmt.Errorf("Unable to communicate with LXD server. Either set " +


### PR DESCRIPTION
This commit removes the LXDContainerPort configuration setting
as it's not used.

It also fixes a misuse of fmt.Errorf.