### PR TITLE
[RFC] Support multiple LXD servers

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -231,25 +231,28 @@ type ConsulDiscoveryConfig struct {
 }
 
 type LXDDiscoveryConfig struct {
-	LXDServerAddress        string `toml:"lxd_server_address" json:"lxd_server_address"`
-	LXDServerRemoteName     string `toml:"lxd_server_remote_name" json:"lxd_server_remote_name"`
-	LXDServerRemotePassword string `toml:"lxd_server_remote_password" json:"lxd_server_remote_password"`
+	LXDServers map[string]*LXDDiscoveryServerConfig `toml:"lxd_servers" json:"lxd_servers"`
 
 	LXDConfigDirectory     string `toml:"lxd_config_directory" json:"lxd_config_directory"`
 	LXDGenerateClientCerts bool   `toml:"lxd_generate_client_certs" json:"lxd_generate_client_certs"`
 	LXDAcceptServerCert    bool   `toml:"lxd_accept_server_cert" json:"lxd_accept_server_cert"`
 
-	LXDContainerLabelKey   string `toml:"lxd_container_label_key" json:"lxd_container_label_key"`
-	LXDContainerLabelValue string `toml:"lxd_container_label_value" json:"lxd_container_label_value"`
+	LXDContainerLabelKey     string `toml:"lxd_container_label_key" json:"lxd_container_label_key"`
+	LXDContainerLabelValue   string `toml:"lxd_container_label_value" json:"lxd_container_label_value"`
+	LXDContainerInterfaceKey string `toml:"lxd_container_interface_key" json:"lxd_container_interface_key"`
 
 	LXDContainerPort    int    `toml:"lxd_container_port" json:"lxd_container_port"`
 	LXDContainerPortKey string `toml:"lxd_container_port_key" json:"lxd_container_port_key"`
 
-	LXDContainerInterface    string `toml:"lxd_container_interface" json:"lxd_container_interface"`
-	LXDContainerInterfaceKey string `toml:"lxd_container_interface_key" json:"lxd_container_interface_key"`
+	LXDContainerSNIKey string `toml:"lxd_container_sni_key" json:"lxd_container_sni_key"`
+}
 
-	LXDContainerSNIKey      string `toml:"lxd_container_sni_key" json:"lxd_container_sni_key"`
-	LXDContainerAddressType string `toml:"lxd_container_address_type" json:"lxd_container_address_type"`
+type LXDDiscoveryServerConfig struct {
+	ServerAddress        string `toml:"server_address" json:"server_address"`
+	ServerRemotePassword string `toml:"server_remote_password" json:"server_remote_password"`
+
+	ContainerInterface   string `toml:"container_interface" json:"container_interface"`
+	ContainerAddressType string `toml:"container_address_type" json:"container_address_type"`
 }
 
 /**

--- a/src/discovery/lxd.go
+++ b/src/discovery/lxd.go
@@ -45,10 +45,31 @@ func NewLXDDiscovery(cfg config.DiscoveryConfig) interface{} {
  * Fetch backends from LXD API
  */
 func lxdFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
-	log := logging.For("lxdFetch")
+	/* Create backends for all LXD servers */
+	backends := []core.Backend{}
+
+	/* For each defined LXD server */
+	for lxdServerRemoteName, lxdServerConfig := range cfg.LXDServers {
+		lxdServerBackends, err := lxdQueryServer(cfg, lxdServerRemoteName, *lxdServerConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		backends = append(backends, lxdServerBackends...)
+	}
+
+	return &backends, nil
+}
+
+func lxdQueryServer(cfg config.DiscoveryConfig, lxdServerRemoteName string, lxdServerConfig config.LXDDiscoveryServerConfig) ([]core.Backend, error) {
+	logLabel := fmt.Sprintf("lxdFetch %s", lxdServerRemoteName)
+	log := logging.For(logLabel)
+
+	/* Create backends for a single LXD server */
+	backends := []core.Backend{}
 
 	/* Get an LXD client */
-	client, err := lxdBuildClient(cfg)
+	client, err := lxdBuildClient(cfg, lxdServerRemoteName, lxdServerConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -56,10 +77,7 @@ func lxdFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 	/* Set the timeout for the client */
 	client.Http.Timeout = utils.ParseDurationOrDefault(cfg.Timeout, lxdTimeout)
 
-	log.Debug("Fetching containers from ", client.Config.Remotes[cfg.LXDServerRemoteName].Addr)
-
-	/* Create backends from response */
-	backends := []core.Backend{}
+	log.Debug("Fetching containers from ", client.Config.Remotes[lxdServerRemoteName].Addr)
 
 	/* Fetch containers */
 	containers, err := client.ListContainers()
@@ -104,13 +122,13 @@ func lxdFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 
 		/* iface is the container interface to get an IP address. */
 		/* This isn't exposed by the LXD API, and containers can have multiple interfaces, */
-		iface := cfg.LXDContainerInterface
+		iface := lxdServerConfig.ContainerInterface
 		if v, ok := container.Config[cfg.LXDContainerInterfaceKey]; ok {
 			iface = v
 		}
 
 		ip := ""
-		if ip, err = lxdDetermineContainerIP(client, container.Name, iface, cfg.LXDContainerAddressType); err != nil {
+		if ip, err = lxdDetermineContainerIP(client, container.Name, iface, lxdServerConfig.ContainerAddressType); err != nil {
 			log.Error(fmt.Sprintf("Can't determine %s container ip address: %s. Skipping", container.Name, err))
 			continue
 		}
@@ -134,25 +152,26 @@ func lxdFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 		})
 	}
 
-	return &backends, nil
+	return backends, nil
 }
 
 /**
  * Create new LXD Client
  */
-func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
-	log := logging.For("lxdBuildClient")
+func lxdBuildClient(cfg config.DiscoveryConfig, lxdServerRemoteName string, lxdServerConfig config.LXDDiscoveryServerConfig) (*lxd.Client, error) {
+	logLabel := fmt.Sprintf("lxdBuildClient %s", lxdServerRemoteName)
+	log := logging.For(logLabel)
 
 	/* Make a client to pass around */
 	var client *lxd.Client
 
 	/* Build a configuration with the requested options */
-	lxdConfig, err := lxdBuildConfig(cfg)
+	lxdConfig, err := lxdBuildConfig(cfg, lxdServerRemoteName, lxdServerConfig)
 	if err != nil {
 		return client, err
 	}
 
-	if strings.HasPrefix(cfg.LXDServerAddress, "https:") {
+	if strings.HasPrefix(lxdServerConfig.ServerAddress, "https:") {
 
 		/* Validate or generate certificates on the client side (gobetween) */
 		if err := lxdhelpers.ValidateClientCertificates(lxdConfig, cfg.LXDGenerateClientCerts); err != nil {
@@ -160,7 +179,7 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 		}
 
 		/* Validate or accept certificates on the server side (LXD) */
-		serverCertf := lxdConfig.ServerCertPath(cfg.LXDServerRemoteName)
+		serverCertf := lxdConfig.ServerCertPath(lxdServerRemoteName)
 		if !shared.PathExists(serverCertf) {
 
 			/* If the server certificate was not found, either gobetween and the LXD server are set
@@ -169,7 +188,7 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 			 *
 			 * First, create a simple LXD client
 			 */
-			client, err = lxd.NewClient(&lxdConfig, cfg.LXDServerRemoteName)
+			client, err = lxd.NewClient(&lxdConfig, lxdServerRemoteName)
 			if err != nil {
 				return nil, err
 			}
@@ -183,7 +202,7 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 			if _, err := client.GetServerConfig(); err != nil {
 				if cfg.LXDAcceptServerCert {
 					var err error
-					client, err = lxdhelpers.GetRemoteCertificate(client, cfg.LXDServerRemoteName)
+					client, err = lxdhelpers.GetRemoteCertificate(client, lxdServerRemoteName)
 					if err != nil {
 						return nil, fmt.Errorf("Could not add the LXD server: ", err)
 					}
@@ -203,7 +222,7 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 			 * Authentication must happen even if PKI is in use.
 			 */
 			log.Info("Attempting to authenticate")
-			err = lxdhelpers.ValidateRemoteConnection(client, cfg.LXDServerRemoteName, cfg.LXDServerRemotePassword)
+			err = lxdhelpers.ValidateRemoteConnection(client, lxdServerRemoteName, lxdServerConfig.ServerRemotePassword)
 			if err != nil {
 				log.Info("Authentication unsuccessful")
 				return nil, err
@@ -214,7 +233,7 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 	}
 
 	/* Build a new client */
-	client, err = lxd.NewClient(&lxdConfig, cfg.LXDServerRemoteName)
+	client, err = lxd.NewClient(&lxdConfig, lxdServerRemoteName)
 	if err != nil {
 		return nil, err
 	}
@@ -230,17 +249,18 @@ func lxdBuildClient(cfg config.DiscoveryConfig) (*lxd.Client, error) {
 /**
  * Create LXD Client Config
  */
-func lxdBuildConfig(cfg config.DiscoveryConfig) (lxd.Config, error) {
-	log := logging.For("lxdBuildConfig")
+func lxdBuildConfig(cfg config.DiscoveryConfig, lxdServerRemoteName string, lxdServerConfig config.LXDDiscoveryServerConfig) (lxd.Config, error) {
+	logLabel := fmt.Sprintf("lxdBuildConfig %s", lxdServerRemoteName)
+	log := logging.For(logLabel)
 
-	log.Debug("Using API: ", cfg.LXDServerAddress)
+	log.Debug("Using API: ", lxdServerConfig.ServerAddress)
 
 	/* Build an LXD configuration that will connect to the requested LXD server */
 	config := lxd.Config{
 		ConfigDir: cfg.LXDConfigDirectory,
 		Remotes:   make(map[string]lxd.RemoteConfig),
 	}
-	config.Remotes[cfg.LXDServerRemoteName] = lxd.RemoteConfig{Addr: cfg.LXDServerAddress}
+	config.Remotes[lxdServerRemoteName] = lxd.RemoteConfig{Addr: lxdServerConfig.ServerAddress}
 
 	return config, nil
 }

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -342,36 +342,38 @@ func prepareConfig(name string, server config.Server, defaults config.Connection
 	/* LXD Discovery */
 	if server.Discovery.Kind == "lxd" {
 
-		if server.Discovery.LXDServerAddress == "" {
-			return config.Server{}, errors.New("lxd_server_address is required" + server.Discovery.LXDServerAddress)
+		if len(server.Discovery.LXDServers) == 0 {
+			return config.Server{}, errors.New("At least one LXD server needs to be defined")
 		}
 
-		if !(strings.HasPrefix(server.Discovery.LXDServerAddress, "https:") ||
-			strings.HasPrefix(server.Discovery.LXDServerAddress, "unix:")) {
+		for _, v := range server.Discovery.LXDServers {
+			if v.ServerAddress == "" {
+				return config.Server{}, errors.New("server_address is required")
+			}
 
-			return config.Server{}, errors.New("lxd_server_address should start with either unix:// or https:// but got " + server.Discovery.LXDServerAddress)
-		}
+			if !(strings.HasPrefix(v.ServerAddress, "https:") ||
+				strings.HasPrefix(v.ServerAddress, "unix:")) {
 
-		if server.Discovery.LXDServerRemoteName == "" {
-			server.Discovery.LXDServerRemoteName = "local"
+				return config.Server{}, errors.New("server_address should start with either unix:// or https:// but got " + v.ServerAddress)
+			}
+
+			if v.ContainerInterface == "" {
+				v.ContainerInterface = "eth0"
+			}
+
+			switch v.ContainerAddressType {
+			case
+				"IPv4",
+				"IPv6":
+			case "":
+				v.ContainerAddressType = "IPv4"
+			default:
+				return config.Server{}, errors.New("Invalid lxd_container_address_type. Must be IPv4 or IPv6")
+			}
 		}
 
 		if server.Discovery.LXDConfigDirectory == "" {
 			server.Discovery.LXDConfigDirectory = os.ExpandEnv("$HOME/.config/lxc")
-		}
-
-		if server.Discovery.LXDContainerInterface == "" {
-			server.Discovery.LXDContainerInterface = "eth0"
-		}
-
-		switch server.Discovery.LXDContainerAddressType {
-		case
-			"IPv4",
-			"IPv6":
-		case "":
-			server.Discovery.LXDContainerAddressType = "IPv4"
-		default:
-			return config.Server{}, errors.New("Invalid lxd_container_address_type. Must be IPv4 or IPv6")
 		}
 
 	}


### PR DESCRIPTION
I'm looking for feedback on how to best implement this. 

I can see a few ways of implementing this:

1. Allow _all_ configuration to be repeatable:

```toml
[servers.default]

# ...

  [servers.default.discovery]
  kind = "lxd"

  [servers.default.discovery.lxd.local]
  container_label_key = "user.gobetween.label"
  container_port_key = "user.gobetween.port"
  container_label_value = "web"
  generate_client_certs = true
  accept_server_cert = true
  server_address = "unix:///var/lib/lxd/unix.socket"


  [servers.default.discovery.lxd_servers.lxd-02]
  container_label_key = "user.gobetween.label"
  container_port_key = "user.gobetween.port"
  container_label_value = "web"
  generate_client_certs = true
  accept_server_cert = true
  server_address = "https://lxd-02.example.com:8443"
  server_remote_password = "password"
```

2. Have one global section and a section for each lxd server. The global settings would be applied to all servers. Each lxd server entry would only have a few configuration settings.

```toml
[servers.default]

# ...

  [servers.default.discovery]
  kind = "lxd"

  [servers.default.discovery.lxd]
  container_label_key = "user.gobetween.label"
  container_port_key = "user.gobetween.port"
  container_label_value = "web" 
  generate_client_certs = true
  accept_server_cert = true

  [servers.default.discovery.lxd_servers.local]
  server_address = "unix:///var/lib/lxd/unix.socket"

  [servers.default.discovery.lxd_servers.lxd-02]
  server_address = "https://lxd-02.example.com:8443"
  server_remote_password = "password"
```

3. Similar to 2, but the global settings are the standard settings in the `[servers.default.discovery]` namespace:

```toml
[servers.default]

# ...

  [servers.default.discovery]
  kind = "lxd"
  lxd_container_label_key = "user.gobetween.label"
  lxd_container_port_key = "user.gobetween.port"
  lxd_container_label_value = "web"   # (required) Label to filter containers
  lxd_generate_client_certs = true
  lxd_accept_server_cert = true

  [servers.default.discovery.lxd_servers.local]
  server_address = "unix:///var/lib/lxd/unix.socket"

  [servers.default.discovery.lxd_servers.lxd-02]
  server_address = "https://lxd-02.example.com:8443"
  server_remote_password = "password"
```

4. Allow all settings to be global and per server. If a setting does not exist in a server, it takes the global value. 

This draft PR implements 3 because it seemed like a good mix of everything to critique.

The following configuration settings are able to be set in a per-server config:

* ServerAddress       
* ServerRemotePassword                   
* ContainerInterface  
* ContainerAddressType

All other settings are global, meaning their values are applied to all servers.

There's no rush to review this :)