### PR TITLE
Gobetween API Discovery

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -172,6 +172,7 @@ type DiscoveryConfig struct {
 	*PlaintextDiscoveryConfig
 	*ConsulDiscoveryConfig
 	*LXDDiscoveryConfig
+	*GobetweenDiscoveryConfig
 }
 
 type StaticDiscoveryConfig struct {
@@ -250,6 +251,18 @@ type LXDDiscoveryConfig struct {
 
 	LXDContainerSNIKey      string `toml:"lxd_container_sni_key" json:"lxd_container_sni_key"`
 	LXDContainerAddressType string `toml:"lxd_container_address_type" json:"lxd_container_address_type"`
+}
+
+type GobetweenDiscoveryConfig struct {
+	GobetweenAPIServers map[string]*GobetweenDiscoveryAPIConfig `toml:"gobetween_api_server" json:"gobetween_api_server"`
+}
+
+type GobetweenDiscoveryAPIConfig struct {
+	APIAddress      string `toml:"api_address" json:"api_address"`
+	APIUsername     string `toml:"api_username" json:"api_username"`
+	APIPassword     string `toml:"api_password" json:"api_password"`
+	BackendWeight   int    `toml:"backend_weight" json:"backend_weight"`
+	BackendPriority int    `toml:"backend_priority" json:"backend_priority"`
 }
 
 /**

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -261,6 +261,7 @@ type GobetweenDiscoveryAPIConfig struct {
 	APIAddress      string `toml:"api_address" json:"api_address"`
 	APIUsername     string `toml:"api_username" json:"api_username"`
 	APIPassword     string `toml:"api_password" json:"api_password"`
+	ServerName      string `toml:"server_name" json:"server_name"`
 	BackendWeight   int    `toml:"backend_weight" json:"backend_weight"`
 	BackendPriority int    `toml:"backend_priority" json:"backend_priority"`
 }

--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -30,6 +30,7 @@ func init() {
 	registry["plaintext"] = NewPlaintextDiscovery
 	registry["consul"] = NewConsulDiscovery
 	registry["lxd"] = NewLXDDiscovery
+	registry["gobetween"] = NewGobetweenDiscovery
 }
 
 /**

--- a/src/discovery/gobetween.go
+++ b/src/discovery/gobetween.go
@@ -1,0 +1,161 @@
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"../config"
+	"../core"
+	"../logging"
+	"../utils"
+)
+
+const (
+	GobetweenRetryWaitDuration  = 2 * time.Second
+	GobetweenDefaultHttpTimeout = 5 * time.Second
+)
+
+/**
+ * Create a new Discovery with gobetween fetch func
+ */
+func NewGobetweenDiscovery(cfg config.DiscoveryConfig) interface{} {
+
+	d := Discovery{
+		opts:  DiscoveryOpts{GobetweenRetryWaitDuration},
+		fetch: gobetweenFetch,
+		cfg:   cfg,
+	}
+
+	return &d
+}
+
+/**
+ * Fetch / refresh backends from gobetween server
+ */
+func gobetweenFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
+
+	// Create backends for all API servers
+	var backends []core.Backend
+
+	for serverName, apiConfig := range cfg.GobetweenAPIServers {
+		apiServerBackend, err := gobetweenQueryAPIServer(cfg, *apiConfig, serverName)
+		if err != nil {
+			return nil, err
+		}
+
+		backends = append(backends, *apiServerBackend)
+	}
+
+	return &backends, nil
+}
+
+func gobetweenQueryAPIServer(cfg config.DiscoveryConfig, apiConfig config.GobetweenDiscoveryAPIConfig, serverName string) (*core.Backend, error) {
+	logLabel := fmt.Sprintf("gobetweenAPIFetch %s", apiConfig.APIAddress)
+	log := logging.For(logLabel)
+
+	// Make request
+	apiEndpoint := apiConfig.APIAddress + "/servers"
+
+	timeout := utils.ParseDurationOrDefault(cfg.Timeout, GobetweenDefaultHttpTimeout)
+	client := http.Client{Timeout: timeout}
+	req, err := http.NewRequest("GET", apiEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if apiConfig.APIUsername != "" && apiConfig.APIPassword != "" {
+		req.SetBasicAuth(apiConfig.APIUsername, apiConfig.APIPassword)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	// Read response
+	content, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert JSON response to interface
+	var servers interface{}
+	err = json.Unmarshal(content, &servers)
+	if err != nil {
+		return nil, err
+	}
+
+	// Begin parsing JSON, loop through servers
+	serversMap, ok := servers.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Unable to parse gobetween /servers")
+	}
+
+	serverInfo, ok := serversMap[serverName]
+	if !ok {
+		log.Debugf("Gobetween server %s did not contain server %s",
+			apiConfig.APIAddress, serverName)
+		return nil, nil
+	}
+
+	serverInfoMap, ok := serverInfo.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Unable to parse %s information", serverName)
+	}
+
+	// Determine the downstream address and port
+	var bindPort string
+	var bindHost string
+
+	// Use the API address as the default Host
+	url, err := url.Parse(apiConfig.APIAddress)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse Gobetween API address: %s", err)
+	}
+	hostParts := strings.Split(url.Host, ":")
+	switch len(hostParts) {
+	case 1:
+		bindHost = url.Host
+	case 2:
+		bindHost = hostParts[0]
+	}
+
+	// Parse the discovered server's "bind" property.
+	// If it's in the form of host:port, use those for the backend.
+	// If it's only :port, use the API address.
+	bindParts := strings.Split(serverInfoMap["bind"].(string), ":")
+	if len(bindParts) == 2 {
+		if bindParts[0] != "" {
+			bindHost = bindParts[0]
+		}
+
+		bindPort = bindParts[1]
+	}
+
+	// Build the backend
+	backend := core.Backend{
+		Target: core.Target{
+			Host: bindHost,
+			Port: bindPort,
+		},
+		Weight:   apiConfig.BackendWeight,
+		Priority: apiConfig.BackendPriority,
+		Stats: core.BackendStats{
+			Live: true,
+		},
+	}
+
+	if sni, ok := serverInfoMap["sni"].(string); ok {
+		backend.Sni = sni
+	}
+
+	log.Info(&backend)
+
+	return &backend, nil
+}

--- a/src/discovery/gobetween.go
+++ b/src/discovery/gobetween.go
@@ -42,8 +42,8 @@ func gobetweenFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 	// Create backends for all API servers
 	var backends []core.Backend
 
-	for serverName, apiConfig := range cfg.GobetweenAPIServers {
-		apiServerBackend, err := gobetweenQueryAPIServer(cfg, *apiConfig, serverName)
+	for apiName, apiConfig := range cfg.GobetweenAPIServers {
+		apiServerBackend, err := gobetweenQueryAPIServer(cfg, *apiConfig, apiName)
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +54,7 @@ func gobetweenFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 	return &backends, nil
 }
 
-func gobetweenQueryAPIServer(cfg config.DiscoveryConfig, apiConfig config.GobetweenDiscoveryAPIConfig, serverName string) (*core.Backend, error) {
+func gobetweenQueryAPIServer(cfg config.DiscoveryConfig, apiConfig config.GobetweenDiscoveryAPIConfig, apiName string) (*core.Backend, error) {
 	logLabel := fmt.Sprintf("gobetweenAPIFetch %s", apiConfig.APIAddress)
 	log := logging.For(logLabel)
 
@@ -97,16 +97,16 @@ func gobetweenQueryAPIServer(cfg config.DiscoveryConfig, apiConfig config.Gobetw
 		return nil, fmt.Errorf("Unable to parse gobetween /servers")
 	}
 
-	serverInfo, ok := serversMap[serverName]
+	serverInfo, ok := serversMap[apiConfig.ServerName]
 	if !ok {
 		log.Debugf("Gobetween server %s did not contain server %s",
-			apiConfig.APIAddress, serverName)
+			apiConfig.APIAddress, apiConfig.ServerName)
 		return nil, nil
 	}
 
 	serverInfoMap, ok := serverInfo.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("Unable to parse %s information", serverName)
+		return nil, fmt.Errorf("Unable to parse %s information", apiName)
 	}
 
 	// Determine the downstream address and port

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -376,6 +376,19 @@ func prepareConfig(name string, server config.Server, defaults config.Connection
 
 	}
 
+	/* Gobetween API Discovery */
+	if server.Discovery.Kind == "gobetween" {
+		for _, v := range server.Discovery.GobetweenAPIServers {
+			if v.BackendWeight == 0 {
+				v.BackendWeight = 1
+			}
+
+			if v.BackendPriority == 0 {
+				v.BackendPriority = 1
+			}
+		}
+	}
+
 	/* TODO: Still need to decide how to get rid of this */
 
 	if defaults.MaxConnections == nil {


### PR DESCRIPTION
This commit adds the ability to discover backends via downstream
gobetween servers by reading server information obtained through
the gobetween API. Traffic will be forwarded to the bound address
and port that the downstream gobetween server is listening on,
which will then be forwarded further down the chain.

For #77 