### PR TITLE
show the 'not-matching' SNI

### DIFF
--- a/src/balance/middleware/sni.go
+++ b/src/balance/middleware/sni.go
@@ -70,6 +70,6 @@ func (b *SniBalancer) Elect(ctx core.Context, backends []*core.Backend) (*core.B
 		return b.Delegate.Elect(ctx, backends)
 	}
 
-	return nil, errors.New("Rejecting client due to not matching sni")
+	return nil, errors.New("Rejecting client due to not matching sni [" + sni + "].")
 
 }


### PR DESCRIPTION
When an SNI match fails, display it in the error message. This will greatly assist debugging.

Hope you consider this change, I have tested this on my local setup with a local build.
* If gobetween itself doesn't show me the SNI, I have to run a separate "snidump" type utility.

Regards,
Shantanu