### PR TITLE
Update CentOS before making the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:7
 
+RUN yum -y update && yum -y clean all
+
 COPY bin/gobetween  /usr/bin/
 
 CMD ["/usr/bin/gobetween", "-c", "/etc/gobetween/conf/gobetween.toml"]


### PR DESCRIPTION
Update the CentOS 7 to get the latest bits.
Possibly helpful if packages like glibc/ca-certificates have been updated.