### PR TITLE
[WIP] Implement proxy-protocol v1 support for TCP server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ deps: clean-deps
 	github.com/gin-contrib/cors \
 	github.com/lxc/lxd/client \
 	github.com/lxc/lxd/lxc/config \
-	github.com/jtopjian/lxdhelpers
+	github.com/jtopjian/lxdhelpers \
+	github.com/pires/go-proxyproto
 
 clean-dist:
 	rm -rf ./dist/${VERSION}
@@ -108,4 +109,3 @@ build-container-latest: build
 build-container-tagged: build
 	@echo Building docker container ${VERSION}
 	docker build -t yyyar/gobetween:${VERSION} .
-

--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -53,7 +53,7 @@ backend_connection_timeout = "0" # Backend connection timeout (ignored in udp)
 
 [servers.sample]
 protocol = "tcp"
-bind = "localhost:3000"
+bind = "0.0.0.0:3000"
 
   [servers.sample.discovery]
   kind = "static"
@@ -152,6 +152,13 @@ protocol = "udp"
 #    "deny 192.168.0.1",     #   are checked in sequence until match,
 #    "allow 192.168.0.1/24"  #   if no match, use 'default' order. ipv4 and ipv6 are supported
 #  ]
+#
+## -------------------- proxy protocol properties -------------------- #
+#
+## For more details on PROXYPROTOCOL see https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+#
+#  [servers.default.proxy_protocol]  # (optional)
+#  version = "1"                     # (required) proxy protocol version. only "1" for now.
 #
 ## -------------------- healthchecks ------------------------- #
 #

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -73,9 +73,6 @@ type Server struct {
 	// tcp | udp | tls
 	Protocol string `toml:"protocol" json:"protocol"`
 
-	// v1
-	ProxyProtocol string `toml:"proxy_protocol" json:"proxy_protocol"`
-
 	// weight | leastconn | roundrobin
 	Balance string `toml:"balance" json:"balance"`
 
@@ -94,11 +91,21 @@ type Server struct {
 	// Access configuration
 	Access *AccessConfig `toml:"access" json:"access"`
 
+	// ProxyProtocol configuration
+	ProxyProtocol *ProxyProtocol `toml:"proxy_protocol" json:"proxy_protocol"`
+
 	// Discovery configuration
 	Discovery *DiscoveryConfig `toml:"discovery" json:"discovery"`
 
 	// Healthcheck configuration
 	Healthcheck *HealthcheckConfig `toml:"healthcheck" json:"healthcheck"`
+}
+
+/**
+ * ProxyProtocol configurtion
+ */
+type ProxyProtocol struct {
+	Version string `toml:"version" json:"version"`
 }
 
 /**

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -73,6 +73,9 @@ type Server struct {
 	// tcp | udp | tls
 	Protocol string `toml:"protocol" json:"protocol"`
 
+	// v1
+	ProxyProtocol string `toml:"proxy_protocol" json:"proxy_protocol"`
+
 	// weight | leastconn | roundrobin
 	Balance string `toml:"balance" json:"balance"`
 

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -219,6 +219,21 @@ func prepareConfig(name string, server config.Server, defaults config.Connection
 		server.Healthcheck.Passes = 1
 	}
 
+	if server.ProxyProtocol != nil {
+
+		if server.Protocol != "tcp" {
+			return config.Server{}, errors.New("proxy_protocol may be used only with 'tcp' protocol, not with " + server.Protocol)
+		}
+
+		if server.ProxyProtocol.Version == "" {
+			return config.Server{}, errors.New("version field for proxy_protocol is not specified")
+		}
+
+		if server.ProxyProtocol.Version != "1" {
+			return config.Server{}, errors.New("Unsupported proxy_protocol version " + server.ProxyProtocol.Version)
+		}
+	}
+
 	if server.Sni != nil {
 
 		if server.Sni.ReadTimeout == "" {

--- a/src/utils/proxyprotocol/proxyprotocol.go
+++ b/src/utils/proxyprotocol/proxyprotocol.go
@@ -1,0 +1,62 @@
+package proxyprotocol
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	proxyproto "github.com/pires/go-proxyproto"
+)
+
+func addrToIPAndPort(addr net.Addr) (ip net.IP, port uint16, err error) {
+	ipString, portString, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return
+	}
+
+	ip = net.ParseIP(ipString)
+	if ip == nil {
+		err = fmt.Errorf("Could not parse IP")
+		return
+	}
+
+	p, err := strconv.ParseInt(portString, 10, 64)
+	if err != nil {
+		return
+	}
+	port = uint16(p)
+	return
+}
+
+/// SendProxyProtocolV1 sends a proxy protocol v1 header to initialize the connection
+/// https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+func SendProxyProtocolV1(client net.Conn, backend net.Conn) error {
+	sourceIP, sourcePort, err := addrToIPAndPort(client.RemoteAddr())
+	if err != nil {
+		return err
+	}
+
+	destinationIP, destinationPort, err := addrToIPAndPort(client.LocalAddr())
+	if err != nil {
+		return err
+	}
+
+	h := proxyproto.Header{
+		Version:            1,
+		SourceAddress:      sourceIP,
+		SourcePort:         sourcePort,
+		DestinationAddress: destinationIP,
+		DestinationPort:    destinationPort,
+	}
+	if sourceIP.To4() != nil {
+		h.TransportProtocol = proxyproto.TCPv4
+	} else {
+		h.TransportProtocol = proxyproto.TCPv6
+	}
+
+	_, err = h.WriteTo(backend)
+	if err != nil {
+		return nil
+	}
+	return nil
+}


### PR DESCRIPTION
I have thrown together a small patch to include proxy-protocol v1 support for TCP.
This is not meant as a final implementation, but more a working proof of concept.

### TODO
- [x] Test if IPv6 is relayed correctly
- [x] Improve error handling and logging
- [x] Cleanup
- [x] Add config validation

### Testing
To test it, I have deployed the [echoheaders](https://github.com/kubernetes/contrib/tree/master/ingress/echoheaders)  application in my kubernetes cluster and setup gobetween to direct traffic to the same ports haproxy does now.
I than checked if the `x-forwarded-for` header is set to the same client IP as reported for the haproxy setup.

Gobetween config (Note the added `proxy_protocol` setting)
```toml
[servers.sample]
bind = "0.0.0.0:9090"
protocol = "tcp"
balance = "roundrobin"
proxy_protocol = "v1"

max_connections = 10000
client_idle_timeout = "10m"
backend_idle_timeout = "10m"
backend_connection_timeout = "2s"

[servers.sample.discovery]
kind = "static"
static_list = [
    "192.168.100.11:31728",
    "192.168.100.12:31728",
    "192.168.100.13:31728"
]
```
You can see the output of the haproxy setup here:
http://headers.cluster.thetechnick.ninja/

### Why I did not implement v2 yet:
It seems that nginx does not support v2 and HAProxy have no UDP support at all.

The proxy-protocol v1 spec () does not cover UDP:
> [...]
> a string indicating the proxied INET protocol and family. As of version 1,
    only "TCP4" ( \x54 \x43 \x50 \x34 ) for TCP over IPv4, and "TCP6"
    ( \x54 \x43 \x50 \x36 ) for TCP over IPv6 are allowed
> [...]
https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

While the binary v2 protocol header does allow UDP, I do not have a use case for it right now.
The great lib would support the v2 protocol header though.

Edit:
Link to issue: #100 