### PR TITLE
discovery/lxd: Remove lxdhelpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libacl1-dev
-  
+
 install:
     - make deps
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ deps: clean-deps
 	github.com/gin-contrib/cors \
 	github.com/lxc/lxd/client \
 	github.com/lxc/lxd/lxc/config \
-	github.com/jtopjian/lxdhelpers \
+	github.com/lxc/lxd/shared \
+	github.com/lxc/lxd/shared/api \
 	github.com/pires/go-proxyproto \
 	golang.org/x/crypto/acme/autocert
 


### PR DESCRIPTION
This commit removes the dependency of the external `lxdhelpers` package. The core functionality of the `lxdhelpers` package has been integrated into the upstream LXD client API and so the `lxdhelpers` package is no longer useful.

The additional functions that are added are specific to the LXD discovery plugin - it does not make sense to abstract them into an external package.

Also, Travis has been modified to no longer install the `libacl1-dev` package since this was resolved a month ago (https://github.com/yyyar/gobetween/issues/105).

Just like with #102, I have Terraform configurations [here](https://github.com/jtopjian/terraform-gobetween-dev) which can help with testing. At a minimum, the [`deploy.sh`](https://github.com/jtopjian/terraform-gobetween-dev/blob/master/files/deploy.sh) script can be used to easily create an LXD+gobetween environment.