### PR TITLE
[Add] Support for using the Host Address

### DIFF
--- a/src/discovery/consul.go
+++ b/src/discovery/consul.go
@@ -109,9 +109,16 @@ func consulFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 			sni = split[1]
 		}
 
+		var host string
+		if s.Address != "" {
+			host = s.Address
+		} else {
+			host = entry.Node.Address
+		}
+		
 		backends = append(backends, core.Backend{
 			Target: core.Target{
-				Host: s.Address,
+				Host: host,
 				Port: fmt.Sprintf("%v", s.Port),
 			},
 			Priority: 1,


### PR DESCRIPTION
This adds support for using the Host Address as the Address of Record for the service if the service does not have a address defined.