### PR TITLE
Public methods and /ping endpoint

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -62,6 +62,10 @@ func Start(cfg config.ApiConfig) {
 	attachRoot(r)
 	attachServers(r)
 
+	/* attach endpoints with no auth */
+	p := app.Group("/")
+	attachPublic(p)
+
 	var err error
 	/* start rest api server */
 	if cfg.Tls != nil {

--- a/src/api/public.go
+++ b/src/api/public.go
@@ -1,0 +1,24 @@
+/**
+ * public.go - / rest api implementation
+ *
+ * @author Mike Schroeder <m.schroeder223@gmail.com>
+ */
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+/**
+ * Attaches / handlers
+ */
+func attachPublic(app *gin.RouterGroup) {
+
+	/**
+	 * Simple 200 and OK response
+	 */
+	app.GET("/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+}


### PR DESCRIPTION
Adds a public path group to the api and a /ping endpoint for health checking gobetween servers.