### PR TITLE
[Add] Support for Prometheus Metrics Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.0] - Unreleased
+
+### New Features
+ - Prometheus Metrics Endpoint
+
+### Fixed
+ - CGO Requirement for DNS has been replaced with netgo [#125](https://github.com/yyyar/gobetween/issues/125)
+
+
 ## [0.6.1] - 2018-10-23
 This release brings only bugfixes
 
@@ -32,7 +41,6 @@ This release brings some improvements and bugfixes.
 - Removed not necessary dependency on libacl1-dev
 - Replaced missing dependencies
 - Removed lxdhelpers (PR #113 by Joe Topjian)
-
 
 
 ## [0.5.0] - 2017-10-13

--- a/config/gobetween.json
+++ b/config/gobetween.json
@@ -3,6 +3,10 @@
         "enabled": true,
         "bind": "0.0.0.0:8888"
     },
+    "metrics": {
+        "enabled": true,
+        "bind": ":9284"
+    },
     "servers": {
         "sample":{
             "bind":"localhost:3000",

--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -30,6 +30,12 @@ cors = false    # cross-origin resource sharing
 #  cert_path = "/path/to/cert.pem"  # Path to certificate
 #  key_path = "/path/to/key.pem"    # Path to key
 
+#
+# Metrics server configuration
+#
+[metrics]
+enabled = true  # true | false
+bind = ":9284"  # "host:port"
 
 #
 # Default values for server configuration, may be overriden in [servers] sections.

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -8,8 +8,8 @@ package api
 import (
 	"../config"
 	"../logging"
-	"github.com/gin-gonic/gin"
 	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
 )
 
 /* gin app */

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -12,6 +12,7 @@ package config
 type Config struct {
 	Logging  LoggingConfig     `toml:"logging" json:"logging"`
 	Api      ApiConfig         `toml:"api" json:"api"`
+	Metrics  MetricsConfig     `toml:"metrics" json:"metrics"`
 	Defaults ConnectionOptions `toml:"defaults" json:"defaults"`
 	Acme     *AcmeConfig       `toml:"acme" json:"acme"`
 	Servers  map[string]Server `toml:"servers" json:"servers"`
@@ -50,6 +51,14 @@ type ApiBasicAuthConfig struct {
 type ApiTlsConfig struct {
 	CertPath string `toml:"cert_path" json:"cert_path"`
 	KeyPath  string `toml:"key_path" json:"key_path"`
+}
+
+/**
+ * Metrics config section
+ */
+type MetricsConfig struct {
+	Enabled bool   `toml:"enabled" json:"enabled"`
+	Bind    string `toml:"bind" json:"bind"`
 }
 
 /**

--- a/src/discovery/consul.go
+++ b/src/discovery/consul.go
@@ -7,15 +7,16 @@
 package discovery
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"../config"
 	"../core"
 	"../logging"
 	"../utils"
-	"fmt"
 	consul "github.com/hashicorp/consul/api"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const (
@@ -44,7 +45,7 @@ func consulFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 
 	log := logging.For("consulFetch")
 
-	log.Info("Fetching ", cfg)
+	log.Debug("Fetching ", cfg)
 
 	// Prepare vars for http client
 	// TODO move http & consul client creation to constructor
@@ -115,7 +116,7 @@ func consulFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 		} else {
 			host = entry.Node.Address
 		}
-		
+
 		backends = append(backends, core.Backend{
 			Target: core.Target{
 				Host: host,

--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -7,10 +7,11 @@
 package discovery
 
 import (
+	"time"
+
 	"../config"
 	"../core"
 	"../logging"
-	"time"
 )
 
 /**

--- a/src/info/info.go
+++ b/src/info/info.go
@@ -4,6 +4,10 @@ import (
 	"time"
 )
 
-var Version string
-var StartTime time.Time
-var Configuration interface{}
+var (
+	Version       string
+	Revision      string
+	Branch        string
+	StartTime     time.Time
+	Configuration interface{}
+)

--- a/src/logging/log.go
+++ b/src/logging/log.go
@@ -9,9 +9,10 @@ package logging
 import (
 	"bytes"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 /**

--- a/src/main.go
+++ b/src/main.go
@@ -5,24 +5,30 @@
 package main
 
 import (
+	"log"
+	"math/rand"
+	"os"
+	"runtime"
+	"time"
+
 	"./api"
 	"./cmd"
 	"./config"
 	"./info"
 	"./logging"
 	"./manager"
+	"./metrics"
 	"./utils/codec"
-	"log"
-	"math/rand"
-	"os"
-	"runtime"
-	"time"
 )
 
 /**
- * Version should be set while build using ldflags (see Makefile)
+ * version,revision,branch should be set while build using ldflags (see Makefile)
  */
-var version string
+var (
+	version  string
+	revision string
+	branch   string
+)
 
 /**
  * Initialize package
@@ -39,6 +45,8 @@ func init() {
 
 	// Save info
 	info.Version = version
+	info.Revision = revision
+	info.Branch = branch
 	info.StartTime = time.Now()
 
 }
@@ -73,6 +81,9 @@ func main() {
 
 		// Start API
 		go api.Start((*cfg).Api)
+
+		/* setup metrics */
+		go metrics.Start((*cfg).Metrics)
 
 		// Start manager
 		go manager.Initialize(*cfg)

--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -1,0 +1,283 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+
+	"../config"
+	"../core"
+	"../info"
+	"../logging"
+	"../stats/counters"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	namespace = "gobetween"
+)
+
+var (
+	metricsDisabled bool = false
+	log                  = logging.For("metrics")
+
+	buildInfo *prometheus.GaugeVec
+	version   string
+	revision  string
+	branch    string
+
+	serverCount             *prometheus.GaugeVec
+	serverActiveConnections *prometheus.GaugeVec
+	serverRxTotal           *prometheus.GaugeVec
+	serverTxTotal           *prometheus.GaugeVec
+	serverRxSecond          *prometheus.GaugeVec
+	serverTxSecond          *prometheus.GaugeVec
+
+	backendActiveConnections  *prometheus.GaugeVec
+	backendRefusedConnections *prometheus.GaugeVec
+	backendTotalConnections   *prometheus.GaugeVec
+	backendRxBytes            *prometheus.GaugeVec
+	backendTxBytes            *prometheus.GaugeVec
+	backendRxSecond           *prometheus.GaugeVec
+	backendTxSecond           *prometheus.GaugeVec
+	backendLive               *prometheus.GaugeVec
+)
+
+func defineMetrics() {
+
+	buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "build_info",
+		Help: fmt.Sprintf(
+			"A metric with a constant '1' value labeled by version, revision, branch, and goversion from which %s was built.",
+			namespace,
+		),
+	}, []string{"version", "revision", "branch", "goversion"})
+
+	serverCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "server",
+		Name:      "count",
+		Help:      "Server Count.",
+	}, []string{"server"})
+
+	serverActiveConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "server",
+		Name:      "active_connections",
+		Help:      "Server Actice Connections.",
+	}, []string{"server"})
+
+	serverRxTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "server",
+		Name:      "rx_total",
+		Help:      "Server Rx Total.",
+	}, []string{"server"})
+
+	serverTxTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "server",
+		Name:      "tx_total",
+		Help:      "Server Tx Total.",
+	}, []string{"server"})
+
+	serverRxSecond = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "server",
+		Name:      "rx_second",
+		Help:      "Server Rx per Second.",
+	}, []string{"server"})
+
+	serverTxSecond = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "server",
+		Name:      "tx_second",
+		Help:      "Server Tx per Second.",
+	}, []string{"server"})
+
+	backendActiveConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "active_connections",
+		Help:      "Backend Actice Connections.",
+	}, []string{"server", "host", "port"})
+
+	backendRefusedConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "refused_connections",
+		Help:      "Backend Refused Connections.",
+	}, []string{"server", "host", "port"})
+
+	backendTotalConnections = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "total_connections",
+		Help:      "Backend Total Connections.",
+	}, []string{"server", "host", "port"})
+
+	backendRxBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "rx_bytes",
+		Help:      "Backend Rx Bytes.",
+	}, []string{"server", "host", "port"})
+
+	backendTxBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "tx_bytes",
+		Help:      "Backend Tx Bytes.",
+	}, []string{"server", "host", "port"})
+
+	backendRxSecond = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "rx_second",
+		Help:      "Backend Rx per Second.",
+	}, []string{"server", "host", "port"})
+
+	backendTxSecond = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "tx_second",
+		Help:      "Backend Tx per Second.",
+	}, []string{"server", "host", "port"})
+
+	backendLive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "backend",
+		Name:      "live",
+		Help:      "Backend Alive.",
+	}, []string{"server", "host", "port"})
+
+}
+
+func Start(cfg config.MetricsConfig) {
+
+	if !cfg.Enabled {
+		log.Info("Metrics disabled")
+		metricsDisabled = true
+		return
+	}
+
+	log.Info("Starting up Metrics server ", cfg.Bind)
+	defineMetrics()
+
+	prometheus.MustRegister(buildInfo)
+	buildInfo.WithLabelValues(info.Version, info.Revision, info.Branch, runtime.Version()).Set(1)
+
+	prometheus.MustRegister(serverCount)
+	prometheus.MustRegister(serverActiveConnections)
+	prometheus.MustRegister(serverRxTotal)
+	prometheus.MustRegister(serverTxTotal)
+	prometheus.MustRegister(serverRxSecond)
+	prometheus.MustRegister(serverTxSecond)
+
+	prometheus.MustRegister(backendActiveConnections)
+	prometheus.MustRegister(backendRefusedConnections)
+	prometheus.MustRegister(backendTotalConnections)
+	prometheus.MustRegister(backendRxBytes)
+	prometheus.MustRegister(backendTxBytes)
+	prometheus.MustRegister(backendRxSecond)
+	prometheus.MustRegister(backendTxSecond)
+	prometheus.MustRegister(backendLive)
+
+	http.Handle("/metrics", promhttp.Handler())
+	go func() {
+		fmt.Errorf("%s", http.ListenAndServe(cfg.Bind, nil))
+	}()
+}
+
+func RemoveServer(server string, backends map[core.Target]*core.Backend) {
+	if metricsDisabled {
+		return
+	}
+
+	serverCount.DeleteLabelValues(server)
+	serverActiveConnections.DeleteLabelValues(server)
+	serverRxTotal.DeleteLabelValues(server)
+	serverTxTotal.DeleteLabelValues(server)
+	serverRxSecond.DeleteLabelValues(server)
+	serverTxSecond.DeleteLabelValues(server)
+
+	for _, backend := range backends {
+		RemoveBackend(server, backend)
+	}
+}
+
+func RemoveBackend(server string, backend *core.Backend) {
+	if metricsDisabled {
+		return
+	}
+
+	backendActiveConnections.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendRefusedConnections.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendTotalConnections.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendRxBytes.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendTxBytes.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendRxSecond.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendTxSecond.DeleteLabelValues(server, backend.Host, backend.Port)
+	backendLive.DeleteLabelValues(server, backend.Host, backend.Port)
+}
+
+func ReportHandleBackendLiveChange(server string, target core.Target, live bool) {
+	if metricsDisabled {
+		return
+	}
+
+	intLive := int(0)
+	if live {
+		intLive = 1
+	}
+
+	backendLive.WithLabelValues(server, target.Host, target.Port).Set(float64(intLive))
+}
+
+func ReportHandleConnectionsChange(server string, connections uint) {
+	if metricsDisabled {
+		return
+	}
+
+	serverActiveConnections.WithLabelValues(server).Set(float64(connections))
+}
+
+func ReportHandleStatsChange(server string, bs counters.BandwidthStats) {
+	if metricsDisabled {
+		return
+	}
+
+	serverRxTotal.WithLabelValues(server).Set(float64(bs.RxTotal))
+	serverTxTotal.WithLabelValues(server).Set(float64(bs.TxTotal))
+	serverRxSecond.WithLabelValues(server).Set(float64(bs.RxSecond))
+	serverTxSecond.WithLabelValues(server).Set(float64(bs.TxSecond))
+}
+
+func ReportHandleBackendStatsChange(server string, target core.Target, backends map[core.Target]*core.Backend) {
+	if metricsDisabled {
+		return
+	}
+
+	backend, _ := backends[target]
+
+	serverCount.WithLabelValues(server).Set(float64(len(backends)))
+
+	backendRxBytes.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.RxBytes))
+	backendTxBytes.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.TxBytes))
+	backendRxSecond.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.RxSecond))
+	backendTxSecond.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.TxSecond))
+}
+
+func ReportHandleOp(server string, target core.Target, backends map[core.Target]*core.Backend) {
+	if metricsDisabled {
+		return
+	}
+
+	backend, _ := backends[target]
+
+	backendActiveConnections.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.ActiveConnections))
+	backendRefusedConnections.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.RefusedConnections))
+	backendTotalConnections.WithLabelValues(server, target.Host, target.Port).Set(float64(backend.Stats.TotalConnections))
+}

--- a/src/stats/handler.go
+++ b/src/stats/handler.go
@@ -7,9 +7,12 @@
 package stats
 
 import (
-	"../core"
-	"./counters"
+	"fmt"
 	"time"
+
+	"../core"
+	"../metrics"
+	"./counters"
 )
 
 const (
@@ -23,7 +26,7 @@ const (
 type Handler struct {
 
 	/* Server's name */
-	name string
+	Name string
 
 	/* Server counter */
 	serverCounter *counters.BandwidthCounter
@@ -58,7 +61,7 @@ type Handler struct {
 func NewHandler(name string) *Handler {
 
 	handler := &Handler{
-		name:        name,
+		Name:        name,
 		ServerStats: make(chan counters.BandwidthStats, 1),
 		Traffic:     make(chan core.ReadWriteCount),
 		Connections: make(chan uint),
@@ -103,7 +106,7 @@ func (this *Handler) Start() {
 				this.BackendsCounter.Stop()
 
 				Store.Lock()
-				delete(Store.handlers, this.name)
+				delete(Store.handlers, this.Name)
 				Store.Unlock()
 
 				// close channels
@@ -119,6 +122,8 @@ func (this *Handler) Start() {
 				this.latestStats.RxSecond = b.RxSecond
 				this.latestStats.TxSecond = b.TxSecond
 
+				metrics.ReportHandleStatsChange(fmt.Sprintf("%s", this.Name), b)
+
 			/* New server backends with stats available */
 			case backends := <-this.Backends:
 				this.latestStats.Backends = backends
@@ -126,6 +131,8 @@ func (this *Handler) Start() {
 			/* New sever connections count available */
 			case connections := <-this.Connections:
 				this.latestStats.ActiveConnections = connections
+
+				metrics.ReportHandleConnectionsChange(fmt.Sprintf("%s", this.Name), connections)
 
 			/* New traffic stats available */
 			case rwc := <-this.Traffic:


### PR DESCRIPTION
This Adds a Prometheus Metrics Endpoint at port 9284.

Currently the service would need to be restarted to clear out old metrics. Still not sure how I want to handle the cleanup of that. But this does what we want for our use case.

Always up for Feedback.