### PR TITLE
Fix Sirupsen/logrus dependency as per author recommendations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ deps: clean-deps
 	github.com/BurntSushi/toml \
 	github.com/miekg/dns \
 	github.com/fsouza/go-dockerclient \
-	github.com/Sirupsen/logrus \
+	github.com/sirupsen/logrus \
 	github.com/elgs/gojq \
 	github.com/gin-gonic/gin \
 	github.com/hashicorp/consul/api \

--- a/src/logging/log.go
+++ b/src/logging/log.go
@@ -9,7 +9,7 @@ package logging
 import (
 	"bytes"
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"os"
 	"strings"
 )


### PR DESCRIPTION
I was getting the following error when trying to `make deps` on both MacOS and Linux, which prompted this change.
```
GOPATH=./dev/go/src/github.com/yyyar/gobetween/vendor go get -u -v \
        github.com/BurntSushi/toml \
        github.com/miekg/dns \
        github.com/fsouza/go-dockerclient \
        github.com/Sirupsen/logrus \
        github.com/elgs/gojq \
        github.com/gin-gonic/gin \
        github.com/hashicorp/consul/api \
        github.com/spf13/cobra \
        github.com/Microsoft/go-winio \
        golang.org/x/sys/windows \
        github.com/inconshreveable/mousetrap \
        github.com/gin-contrib/cors \
        github.com/lxc/lxd/client \
        github.com/lxc/lxd/lxc/config \
        github.com/lxc/lxd/shared \
        github.com/lxc/lxd/shared/api \
        github.com/pires/go-proxyproto \
        golang.org/x/crypto/acme/autocert
github.com/BurntSushi/toml (download)
github.com/miekg/dns (download)
github.com/fsouza/go-dockerclient (download)
github.com/docker/docker (download)
github.com/docker/go-units (download)
github.com/sirupsen/logrus (download)
[...]
github.com/Nvveen/Gotty (download)
github.com/Sirupsen/logrus (download)
package github.com/Sirupsen/logrus: case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus"
github.com/elgs/gojq (download)
[...]
```

See here for a discussion, and community decision that the way forward is to rename usages to `sirupsen`: https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276

Only remaining reference to the uppercase one is in the consul dependency, however it doesn't conflict when building so I assume this is still ok.