### PR TITLE
container build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ dist:
 	  fi \
 	done
 
-build-container-latest: build
+build-container-latest: build-static
 	@echo Building docker container LATEST
 	docker build -t yyyar/gobetween .
 
-build-container-tagged: build
+build-container-tagged: build-static
 	@echo Building docker container ${VERSION}
 	docker build -t yyyar/gobetween:${VERSION} .


### PR DESCRIPTION
For now container image dehydrated to from:scratch , so it static build is a requirement for such containers.
this fix change  dynamically linked gobetween build as a first step of container build to  a static build.