### PR TITLE
Support to deploy gobetween as Pod in K8s cluster

### DIFF
--- a/gb_k8s_deploy.yaml
+++ b/gb_k8s_deploy.yaml
@@ -1,0 +1,38 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: gobetween
+spec:
+  selector:
+    app: gobetween
+  ports:
+  - name: "gobetween"
+    protocol: TCP
+    port: 80
+    nodePort: 32345
+  type: NodePort
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gobetween
+  labels:
+    app: gobetween
+spec:
+  containers:
+  - name: gobetween
+    image: yyyar/gobetween:latest
+    env:
+    - name: GOBETWEEN
+      value: ""
+    ports:
+    - name: gobetween
+      containerPort: 80
+    volumeMounts:
+    - name: config
+      mountPath: /etc/gobetween/conf
+      readOnly: false
+  volumes:
+  - name: config
+    configMap:
+      name: gb


### PR DESCRIPTION
Adding support to deploy gobetween as Pod/Container in Kubernetes cluster.
**Steps to Launch:**
1. Create ConfigMap **gb** with config gobetween.toml
`$ kubectl create configmap gb --save-config --from-file=<location-of-gobetween.toml> -o yaml | kubectl apply -f -`
2. Launch pod running gobetween container using above ConfigMap
`$ kubectl apply -f gb_k8s_deploy.yaml`

Result/Logs after gobetween is launched.
```
$ kubectl logs gobetween
2019/01/22 10:15:29 gobetween v0.6.1
2019-01-22 10:15:29 [INFO ] (manager): Initializing...
2019-01-22 10:15:29 [INFO ] (api): Starting up API
2019-01-22 10:15:29 [INFO ] (api): Starting HTTP server :8888
2019-01-22 10:15:29 [INFO ] (server): Creating 'sample': 0.0.0.0:3000 weight static none
2019-01-22 10:15:29 [INFO ] (scheduler): Starting scheduler
2019-01-22 10:15:29 [INFO ] (udp/server): Creating UDP server 'udpsample': localhost:4000 weight static none
2019-01-22 10:15:34 [INFO ] (scheduler): Starting scheduler
2019-01-22 10:15:34 [INFO ] (manager): Initialized
```



 