### PR TITLE
fix: Dockerfile scratch create bugs, switch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+FROM alpine:latest
+
 COPY bin/gobetween  /usr/bin/
 CMD ["/usr/bin/gobetween", "-c", "/etc/gobetween/conf/gobetween.toml"]
 


### PR DESCRIPTION
Docker scratch image create bugs because there is not bash installed

```
gobetween_1     | 2019-01-22 14:52:37 [WARNI] (healthcheck/exec): fork/exec /healthcheck.sh: no such file or directory
gobetween_1     | 2019-01-22 14:52:37 [INFO ] (healthcheck/worker): Sending to scheduler: {{udp-server-1 1153} false}
```

⚠️ i didn't test it, because build need the app build, and i had issue with is, 
i use alpine to have a small base image, but there is no `bash` in alpine, only `sh`

you can merge if it's ok, or i can change to `ubuntu:latest` (or any version if needed) 