### PR TITLE
Added new balance mechanism "priority".

### DIFF
--- a/src/balance/priority.go
+++ b/src/balance/priority.go
@@ -1,7 +1,7 @@
 /**
- * weight.go - weight balance impl
+ * priority.go - priority balance implementation
  *
- * @author Yaroslav Pogrebnyak <yyyaroslav@gmail.com>
+ * @author quedunk <quedunk@gmail.com>
  */
 
 package balance

--- a/src/balance/priority.go
+++ b/src/balance/priority.go
@@ -1,0 +1,56 @@
+/**
+ * weight.go - weight balance impl
+ *
+ * @author Yaroslav Pogrebnyak <yyyaroslav@gmail.com>
+ */
+
+package balance
+
+import (
+	"../core"
+	"errors"
+	"math/rand"
+)
+
+/**
+ * Weight balancer
+ */
+type PriorityBalancer struct{}
+
+/**
+ * Elect backend based on weight strategy
+ */
+func (b *PriorityBalancer) Elect(context core.Context, backends []*core.Backend) (*core.Backend, error) {
+
+	if len(backends) == 0 {
+		return nil, errors.New("Can't elect backend, Backends empty")
+	}
+
+	/* count the backends with the same priority */
+	matchingPriority := 0
+	bestPriority := 0
+	for _, backend := range backends {
+		if (matchingPriority == 0 || backend.Priority < bestPriority) {
+			bestPriority = backend.Priority
+			matchingPriority = 1
+		} else if backend.Priority == bestPriority  {
+			bestPriority = backend.Priority
+			matchingPriority ++;
+		}
+
+	}
+
+	r := rand.Intn(matchingPriority)
+	pos := 0
+
+	for _, backend := range backends {
+		if backend.Priority == bestPriority  {
+			if (pos == r) {
+				return backend, nil
+			}
+			pos ++
+		}
+	}
+
+	return nil, errors.New("Can't elect backend")
+}

--- a/src/balance/registry.go
+++ b/src/balance/registry.go
@@ -30,6 +30,7 @@ func init() {
 	typeRegistry["iphash"] = reflect.TypeOf(IphashBalancer{})
 	typeRegistry["iphash1"] = reflect.TypeOf(Iphash1Balancer{})
 	typeRegistry["leastbandwidth"] = reflect.TypeOf(LeastbandwidthBalancer{})
+	typeRegistry["priority"] = reflect.TypeOf(PriorityBalancer{})
 }
 
 /**

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -471,6 +471,7 @@ func prepareConfig(name string, server config.Server, defaults config.Connection
 	case
 		"weight",
 		"leastconn",
+		"priority",
 		"roundrobin",
 		"leastbandwidth",
 		"iphash1",


### PR DESCRIPTION
Basically only uses healthy backends with the best priority. Others are ignored.
If discovery returns;
1.1.1.1 priority=1
2.2.2.2 priority=2
3.3.3.3 priority=3

Then only 1.1.1.1 will be used.
If 1.1.1.1 is marked as healthcheck down, then only 2.2.2.2 will be used.

If discovery returns
1.1.1.1 priority=1
2.2.2.2 priority=1
3.3.3.3 priority=3

Then both 1.1.1.1 and 2.2.2.2 are used, selected by random.