### PR TITLE
Implement transparent UDP connections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -185,6 +185,7 @@ type BackendsTls struct {
 type Udp struct {
 	MaxRequests  uint64 `toml:"max_requests" json:"max_requests"`
 	MaxResponses uint64 `toml:"max_responses" json:"max_responses"`
+	Transparent  bool   `toml:"transparent" json:"transparent"`
 }
 
 /**

--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -167,6 +167,8 @@ protocol = "udp"
 #  [servers.default.udp]             # (optional)
 #  max_requests  = 0                 # (optional) if > 0 accepts no more requests than max_requests and closes session
 #  max_responses = 0                 # (optional) if > 0 accepts no more responses than max_responses from backend and closes session
+#  transparent = false               # (optional) if true - work in transparent mode, when forwarded udp packets have client source address.
+#                                    #            (requires additional host configuration)
 #
 #
 ## -------------------- access management -------------------- #

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/burntsushi/toml v0.3.1
 	github.com/elgs/gojq v0.0.0-20160421194050-81fa9a608a13
 	github.com/elgs/gosplitargs v0.0.0-20161028071935-a491c5eeb3c8 // indirect
+	github.com/eric-lindau/udpfacade v0.0.0-20190425230512-031998cc71fa
 	github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769 // indirect
 	github.com/fsouza/go-dockerclient v1.3.6
 	github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/elgs/gojq v0.0.0-20160421194050-81fa9a608a13 h1:/voSflvo4UvPT0XZy+YQM
 github.com/elgs/gojq v0.0.0-20160421194050-81fa9a608a13/go.mod h1:rQELVIqRXpraeUryHOBadz99ePvEVQmTVpGr8M9QQ4Q=
 github.com/elgs/gosplitargs v0.0.0-20161028071935-a491c5eeb3c8 h1:bD2/rCXwgXJm2vgoSSSCM9IPjVFfEoQFFblzg7HHABI=
 github.com/elgs/gosplitargs v0.0.0-20161028071935-a491c5eeb3c8/go.mod h1:o4DgpccPNAQAlPSxo7I4L/LWNh2oyr/BBGSynrLTmZM=
+github.com/eric-lindau/udpfacade v0.0.0-20190425230512-031998cc71fa h1:vcabBLB5KsNFFvLiz58J/0/Y1sP9vIMu5CO9tjNN4tU=
+github.com/eric-lindau/udpfacade v0.0.0-20190425230512-031998cc71fa/go.mod h1:FgXLvXZ5hgyfdG0KcbEt7dihoivzIk9puoGiP+2isNE=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769 h1:XToLChWPMXLomJ2InnkrmUkddaXfevrmomMTFL+MaKU=
 github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769/go.mod h1:tbAXHifHQWNSpWbiJHpJTZH5fi3XHhDMdP//vuz9WS4=
@@ -52,6 +54,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCy
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/gopacket v1.1.16 h1:u6Afvia5C5srlLcbTwpHaFW918asLYPxieziOaWwz8M=
+github.com/google/gopacket v1.1.16/go.mod h1:UCLx9mCmAwsVbn6qQl1WIEt2SO7Nd2fD0th1TBAsqBw=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/server/udp/session/config.go
+++ b/server/udp/session/config.go
@@ -7,4 +7,5 @@ type Config struct {
 	MaxResponses       uint64
 	ClientIdleTimeout  time.Duration
 	BackendIdleTimeout time.Duration
+	Transparent        bool
 }

--- a/server/udp/session/session.go
+++ b/server/udp/session/session.go
@@ -57,7 +57,7 @@ type Session struct {
 	clientAddr *net.UDPAddr
 
 	//connection to backend
-	conn    *net.UDPConn
+	conn    net.Conn
 	backend core.Backend
 
 	//communication
@@ -69,7 +69,7 @@ type Session struct {
 	scheduler *scheduler.Scheduler
 }
 
-func NewSession(clientAddr *net.UDPAddr, conn *net.UDPConn, backend core.Backend, scheduler *scheduler.Scheduler, cfg Config) *Session {
+func NewSession(clientAddr *net.UDPAddr, conn net.Conn, backend core.Backend, scheduler *scheduler.Scheduler, cfg Config) *Session {
 
 	scheduler.IncrementConnection(backend)
 	s := &Session{


### PR DESCRIPTION
#203 #121 

Hi there,

I've been hard at work on this - I think it will be quite useful. Please let me know what you think - you can test it (make sure you update dependencies, as there is 1 extra module), but let me demonstrate:

With a basic Python UDP server...
```python
 #/usr/bin/env/python3
import socket

sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
sock.bind(('127.0.0.1', 1025))

while True:
   data, address = sock.recvfrom(65507)
   text = data.decode('ascii')
   print('{}: {}'.format(address, text))
```
...and this config (note the `transparent=true`) with `sudo ./bin/gobetween` (**sudo** required because modifying IP headers requires heightened permissions)...
```toml
[servers.default]
protocol = "udp"
bind = "0.0.0.0:4321"
client_idle_timeout = "50"

  [servers.default.udp]
  max_requests  = 0
  max_responses = 0
  transparent = true
  [servers.default.discovery]
    kind = "static"
    static_list = [
        "localhost:1025"
    ]
```
...using [this test](https://github.com/eric-lindau/udpfacade/blob/master/udp_test.go), we get...

<img width="279" alt="Screen Shot 2019-04-25 at 19 22 52" src="https://user-images.githubusercontent.com/26858154/56774210-ac499b00-678f-11e9-8c59-7bd0f30eb30f.png">
<img width="763" alt="Screen Shot 2019-04-25 at 19 23 18" src="https://user-images.githubusercontent.com/26858154/56774213-afdd2200-678f-11e9-91bf-527ade4b5175.png">
<img width="765" alt="Screen Shot 2019-04-25 at 19 23 38" src="https://user-images.githubusercontent.com/26858154/56774217-b2d81280-678f-11e9-841f-9b81b49857fd.png">

You can imagine it would be extremely easy to modify this in the future to configure explicit source addresses, but I see transparent client requests as the most useful consequence.

I did have to change one method signature because persisting source address requires the storage of additional client information, but I think using net.Conn (the interface of net.UDPConn) is natural here.