### PR TITLE
SRV backend IPv6 support

### DIFF
--- a/src/discovery/srv.go
+++ b/src/discovery/srv.go
@@ -98,7 +98,8 @@ func srvFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 			if ip != "" {
 				hosts[record.Target] = ip
 			} else {
-				log.Warn("No IP fond for ", record.Target, ", skipping...")
+				log.Warn("No IP found for ", record.Target, ", skipping...")
+				continue
 			}
 		}
 

--- a/src/discovery/srv.go
+++ b/src/discovery/srv.go
@@ -65,7 +65,7 @@ func srvFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 		case *dns.A:
 			hosts[record.Header().Name] = record.A.String()
 		case *dns.AAAA:
-			hosts[record.Header().Name] = record.AAAA.String()
+			hosts[record.Header().Name] = fmt.Sprintf("[%s]", record.AAAA.String())
 		}
 	}
 
@@ -153,7 +153,7 @@ func srvIPLookup(cfg config.DiscoveryConfig, pattern string, typ uint16) (string
 	case *dns.A:
 		return ans.A.String(), nil
 	case *dns.AAAA:
-		return ans.AAAA.String(), nil
+		return fmt.Sprintf("[%s]", ans.AAAA.String()), nil
 	default:
 		return "", nil
 	}


### PR DESCRIPTION
The current backend SRV only looks for A records / IPv4 addresses. I wish to use gobetween as the L4 ingress on a Kubernetes cluster where the internal network is IPv6 only

This change:
* Extracts AAAA records from the additional section of the SRV lookup, and
* Performs queries for AAAA records if no IP is found and if an A lookup returns nothing