### PR TITLE
add json format support for logs

### DIFF
--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -12,6 +12,7 @@
 [logging]
 level = "info"   # "debug" | "info" | "warn" | "error"
 output = "stdout" # "stdout" | "stderr" | "/path/to/gobetween.log"
+format = "json" # "json"
 
 #
 # Pprof profiler configuration

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 	cmd.Execute(func(cfg *config.Config) {
 
 		// Configure logging
-		logging.Configure(cfg.Logging.Output, cfg.Logging.Level)
+		logging.Configure(cfg.Logging.Output, cfg.Logging.Level, cfg.Logging.Format)
 
 		// Start API
 		go api.Start((*cfg).Api)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 type LoggingConfig struct {
 	Level  string `toml:"level" json:"level"`
 	Output string `toml:"output" json:"output"`
+	Format string `toml:"format" json:"format"`
 }
 
 /**

--- a/src/logging/log.go
+++ b/src/logging/log.go
@@ -27,7 +27,7 @@ func init() {
 /**
  * Configure logging
  */
-func Configure(output string, l string) {
+func Configure(output string, l string, format string) {
 
 	if output == "" || output == "stdout" {
 		logrus.SetOutput(os.Stdout)
@@ -39,6 +39,10 @@ func Configure(output string, l string) {
 			logrus.Fatal(err)
 		}
 		logrus.SetOutput(f)
+	}
+
+	if format == "json" {
+		logrus.SetFormatter(&logrus.JSONFormatter{})
 	}
 
 	if l == "" {


### PR DESCRIPTION
This PR adds the format option in logging configuration.

 * The format option can be specified only for `json`.
 * If `json` is specified in the format option, the output log format will be JSON format
