### PR TITLE
Do healthcheck upon worker startup without delay

### DIFF
--- a/src/healthcheck/worker.go
+++ b/src/healthcheck/worker.go
@@ -64,6 +64,9 @@ func (this *Worker) Start() {
 	c := make(chan CheckResult, 1)
 
 	go func() {
+		/* Check health before any delay*/
+		log.Debug("Initial check ", this.cfg.Kind, " for ", this.target)
+		go this.check(this.target, this.cfg, c)
 		for {
 			select {
 


### PR DESCRIPTION
This addresses part of https://github.com/yyyar/gobetween/issues/251 where I found it surprising that health check did not occur initially when starting worker, but rather after delay.

This change does not address all of https://github.com/yyyar/gobetween/issues/251