### PR TITLE
Allow workaround for discovery startup race

### DIFF
--- a/src/discovery/discovery.go
+++ b/src/discovery/discovery.go
@@ -136,11 +136,15 @@ func (this *Discovery) Start() {
 				continue
 			}
 
-			// cache
-			this.backends = backends
-			if !this.send() {
-				log.Info("Stopping discovery ", this.cfg)
-				return
+			// Don't prime cache if no backends and about to exit
+			// see https://github.com/yyyar/gobetween/issues/257 for more info
+			if interval != 0 || len(*backends) != 0 {
+				// cache
+				this.backends = backends
+				if !this.send() {
+					log.Info("Stopping discovery ", this.cfg)
+					return
+				}
 			}
 
 			// exit gorouting if no cacheTtl

--- a/src/go.mod
+++ b/src/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/elgs/gojq v0.0.0-20160421194050-81fa9a608a13
 	github.com/elgs/gosplitargs v0.0.0-20161028071935-a491c5eeb3c8 // indirect
 	github.com/eric-lindau/udpfacade v0.0.0-20190621043444-d8c1c27add16
-	github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769 // indirect
+	github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4 // indirect
 	github.com/fsouza/go-dockerclient v1.3.6
 	github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a
 	github.com/gin-gonic/gin v1.3.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -33,6 +33,8 @@ github.com/eric-lindau/udpfacade v0.0.0-20190621043444-d8c1c27add16/go.mod h1:Fg
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769 h1:XToLChWPMXLomJ2InnkrmUkddaXfevrmomMTFL+MaKU=
 github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769/go.mod h1:tbAXHifHQWNSpWbiJHpJTZH5fi3XHhDMdP//vuz9WS4=
+github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4 h1:GY1+t5Dr9OKADM64SYnQjw/w99HMYvQ0A8/JoUkxVmc=
+github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/frankban/quicktest v1.0.0/go.mod h1:R98jIehRai+d1/3Hv2//jOVCTJhW1VBavT6B6CuGq2k=
 github.com/frankban/quicktest v1.1.0 h1:Fw/voXLo2r0Tvu5uy/GV/W5XpT7LYfbrqottX3kz8YE=
 github.com/frankban/quicktest v1.1.0/go.mod h1:R98jIehRai+d1/3Hv2//jOVCTJhW1VBavT6B6CuGq2k=
@@ -44,6 +46,7 @@ github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7 h1:AzN37oI0cOS+cou
 github.com/gin-contrib/sse v0.0.0-20170109093832-22d885f9ecc7/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.3.0 h1:kCmZyPklC0gVdL728E6Aj20uYBJV93nj/TkwBTKhFbs=
 github.com/gin-gonic/gin v1.3.0/go.mod h1:7cKuhb5qV2ggCFctp2fJQ+ErvciLZrIeoOSOm6mUr7Y=
+github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-check/check v1.0.0-20180628173108-788fd7840127 h1:3dbHpVjNKf7Myfit4Xmw4BA0JbCt47OJPhMQ5w8O3E8=
 github.com/go-check/check v1.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=


### PR DESCRIPTION
Related to issue https://github.com/yyyar/gobetween/issues/257

This is not full fix, however will an application that is written correctly to not hit the race. What the application would have to do is create the server with no backends, and then immediately update the backends with the backend pool that they want.

This race can be hit using the rest api, or when embeding gobetween as a library.

```go
manager.Create("foo", config.Server{
    Protocol: "tcp",
    Bind:     "127.0.0.1:199",
    Discovery: &config.DiscoveryConfig{
        Kind:                  "static",
        StaticDiscoveryConfig: &config.StaticDiscoveryConfig{StaticList: []string{}},
    },
})
manager.Modify("foo", &[]core.Backend{core.Backend{Target: core.Target{Host: "127.0.0.1", Port: "8990"}, Stats: core.BackendStats{Live: true}}})
```