### PR TITLE
Add channel that signals server is completed

### DIFF
--- a/src/api/servers.go
+++ b/src/api/servers.go
@@ -57,7 +57,7 @@ func attachServers(app *gin.RouterGroup) {
 			return
 		}
 
-		if err := manager.Create(name, cfg); err != nil {
+		if err := manager.Create(name, cfg, make(chan struct{}, 1)); err != nil {
 			c.IndentedJSON(http.StatusConflict, err.Error())
 			return
 		}

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -61,7 +61,7 @@ func Initialize(cfg config.Config) {
 
 	// Go through config and start servers for each server
 	for name, serverCfg := range cfg.Servers {
-		err := Create(name, serverCfg)
+		err := Create(name, serverCfg, make(chan struct{}, 1))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -181,7 +181,7 @@ func Get(name string) interface{} {
 /**
  * Create new server and launch it
  */
-func Create(name string, cfg config.Server) error {
+func Create(name string, cfg config.Server, completed chan <- struct{}) error {
 
 	servers.Lock()
 	defer servers.Unlock()
@@ -195,7 +195,7 @@ func Create(name string, cfg config.Server) error {
 		return err
 	}
 
-	server, err := server.New(name, c)
+	server, err := server.New(name, c, completed)
 
 	if err != nil {
 		return err

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -19,12 +19,12 @@ import (
 /**
  * Creates new Server based on cfg.Protocol
  */
-func New(name string, cfg config.Server) (core.Server, error) {
+func New(name string, cfg config.Server, completed chan<- struct{}) (core.Server, error) {
 	switch cfg.Protocol {
 	case "tls", "tcp":
-		return tcp.New(name, cfg)
+		return tcp.New(name, cfg, completed)
 	case "udp":
-		return udp.New(name, cfg)
+		return udp.New(name, cfg, completed)
 	default:
 		return nil, errors.New("Can't create server for protocol " + cfg.Protocol)
 	}


### PR DESCRIPTION
Take in a channel that allows caller to determine when the server has exited (this could be graceful, or failure). This fixes https://github.com/yyyar/gobetween/issues/260