### PR TITLE
Encrypted pem config file mods

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -5,6 +5,7 @@ package config
  *
  * @author Yaroslav Pogrebnyak <yyyaroslav@gmail.com>
  * @author Gene Ponomarenko <kikomdev@gmail.com>
+ * @Improver Ben Gabbard <ben.gabbard@live.com>
  */
 
 /**
@@ -168,6 +169,8 @@ type Tls struct {
 	AcmeHosts []string `toml:"acme_hosts" json:"acme_hosts"`
 	CertPath  string   `toml:"cert_path" json:"cert_path"`
 	KeyPath   string   `toml:"key_path" json:"key_path"`
+	key_pass_path  *string `toml:"key_path" json:"key_pass_path"`
+	key_pass       *string `toml:"key_path" json:"key_pass"`
 	tlsCommon
 }
 
@@ -176,6 +179,8 @@ type BackendsTls struct {
 	RootCaCertPath *string `toml:"root_ca_cert_path" json:"root_ca_cert_path"`
 	CertPath       *string `toml:"cert_path" json:"cert_path"`
 	KeyPath        *string `toml:"key_path" json:"key_path"`
+	key_pass_path  *string `toml:"key_path" json:"key_pass_path"`
+	key_pass       *string `toml:"key_path" json:"key_pass"`
 	tlsCommon
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -169,8 +169,8 @@ type Tls struct {
 	AcmeHosts []string `toml:"acme_hosts" json:"acme_hosts"`
 	CertPath  string   `toml:"cert_path" json:"cert_path"`
 	KeyPath   string   `toml:"key_path" json:"key_path"`
-	key_pass_path  *string `toml:"key_path" json:"key_pass_path"`
-	key_pass       *string `toml:"key_path" json:"key_pass"`
+	key_pass_path  string `toml:"key_path" json:"key_pass_path"`
+	key_pass       string `toml:"key_path" json:"key_pass"`
 	tlsCommon
 }
 


### PR DESCRIPTION
This adds the key values to the Tls and backed Tls structs to decrypt encrypted certificate keyfiles. I will add the logic to the config.go file in a future pull request.