### PR TITLE
Suppress i/o timeout error in the UDP load balancer when the backend idle timeout expires

### DIFF
--- a/src/server/udp/session/session.go
+++ b/src/server/udp/session/session.go
@@ -191,6 +191,10 @@ func (s *Session) ListenResponses(sendTo *net.UDPConn) {
 			n, err := s.conn.Read(b)
 
 			if err != nil {
+				if err, ok := err.(net.Error); ok && err.Timeout() {
+					return
+				}
+
 				if atomic.LoadUint32(&s.stopped) == 0 {
 					log.Errorf("Failed to read from backend: %v", err)
 				}


### PR DESCRIPTION
I noticed that while load balancing UDP with `backend_idle_timeout` set in the config, the logs are showing ominous entries of failure when the timer expires:

`2020-04-07 14:01:08 [ERROR] (udp/server/session): Failed to read from backend: read udp 172.27.0.5:38196->172.27.0.4:44445: i/o timeout`

This pull request will suppress those errors with an early return in the error handling code.