### PR TITLE
Add ipporthash1 balancing strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
   * **Roundrobin** - simple elect backend from pool in circular order
   * **Iphash** - route client to the same backend based on client ip hash
   * **Iphash1** - same as iphash but backend removal consistent (clients remain connecting to the same backend, even if some other backends down)
+  * **IpPorthash1** - same as iphash1 but route client to the same backend based on client ip+port hash (this is useful for balancing NATed connections)
   * **Leastconn** - select backend with least active connections
   * **Leastbandwidth** -  backends with least bandwidth
 

--- a/config/gobetween.toml
+++ b/config/gobetween.toml
@@ -115,7 +115,7 @@ protocol = "udp"
 #
 #bind = "localhost:3000"     #  (required) "<host>:<port>"
 #protocol = "tcp"            #  (required) "tcp" | "tls" | "udp"
-#balance = "weight"          #  (optional [weight]) "weight" | "leastconn" | "roundrobin" | "iphash" | "iphash1" | "leastbandwidth"
+#balance = "weight"          #  (optional [weight]) "weight" | "leastconn" | "roundrobin" | "iphash" | "iphash1" | "ipporthash1" | "leastbandwidth"
 #
 #max_connections = 0
 #client_idle_timeout = "10m"

--- a/src/balance/ipporthash1.go
+++ b/src/balance/ipporthash1.go
@@ -1,0 +1,52 @@
+package balance
+
+/**
+ * ipporthash.go - semi-consistent ip-porthash balance impl
+ *
+ * Based on iphash1.go.
+ */
+
+import (
+	"errors"
+	"hash/fnv"
+	"strconv"
+
+	"github.com/yyyar/gobetween/core"
+)
+
+/**
+ * IpPorthash1 balancer
+ */
+type IpPorthash1Balancer struct {
+}
+
+/**
+ * Elect backend using semi-consistent ip+port hash strategy.
+ * This is useful to balance connections coming from a NATed source.
+ *
+ */
+func (b *IpPorthash1Balancer) Elect(context core.Context, backends []*core.Backend) (*core.Backend, error) {
+
+	if len(backends) == 0 {
+		return nil, errors.New("Can't elect backend, Backends empty")
+	}
+
+	var result *core.Backend
+	{
+		var bestHash uint32
+
+		for i, backend := range backends {
+			hasher := fnv.New32a()
+			ipPort := context.Ip().String() + strconv.Itoa(context.Port())
+			hasher.Write([]byte(ipPort))
+			hasher.Write([]byte(backend.Address()))
+			s32 := hasher.Sum32()
+			if s32 > bestHash {
+				bestHash = s32
+				result = backends[i]
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/src/balance/registry.go
+++ b/src/balance/registry.go
@@ -28,6 +28,7 @@ func init() {
 	typeRegistry["weight"] = reflect.TypeOf(WeightBalancer{})
 	typeRegistry["iphash"] = reflect.TypeOf(IphashBalancer{})
 	typeRegistry["iphash1"] = reflect.TypeOf(Iphash1Balancer{})
+	typeRegistry["ipporthash1"] = reflect.TypeOf(IpPorthash1Balancer{})
 	typeRegistry["leastbandwidth"] = reflect.TypeOf(LeastbandwidthBalancer{})
 }
 

--- a/src/manager/manager.go
+++ b/src/manager/manager.go
@@ -482,6 +482,7 @@ func prepareConfig(name string, server config.Server, defaults config.Connection
 		"leastconn",
 		"roundrobin",
 		"leastbandwidth",
+		"ipporthash1",
 		"iphash1",
 		"iphash":
 	case "":


### PR DESCRIPTION
This PR adds ip+port hash balancing strategy.
This is useful in certain scenarios were traffic comes from a NATed network and all source IP distribution is bad for balancing and you need stickiness/affinity to the elected backend.

Feel free to dismiss this PR if you don't find it useful enough.