### PR TITLE
Implement mTLS for servers

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -165,9 +165,11 @@ type tlsCommon struct {
  * for protocol = "tls"
  */
 type Tls struct {
-	AcmeHosts []string `toml:"acme_hosts" json:"acme_hosts"`
-	CertPath  string   `toml:"cert_path" json:"cert_path"`
-	KeyPath   string   `toml:"key_path" json:"key_path"`
+	AcmeHosts  []string `toml:"acme_hosts" json:"acme_hosts"`
+	CertPath   string   `toml:"cert_path" json:"cert_path"`
+	KeyPath    string   `toml:"key_path" json:"key_path"`
+	ClientAuth string   `toml:"client_auth" json:"client_auth"`
+	ClientCA   string   `toml:"client_ca" json:"client_ca"`
 	tlsCommon
 }
 

--- a/src/healthcheck/probe.go
+++ b/src/healthcheck/probe.go
@@ -26,7 +26,7 @@ func probe(t core.Target, cfg config.HealthcheckConfig, result chan<- CheckResul
 	timeout, _ := time.ParseDuration(cfg.Timeout)
 
 	checkResult := CheckResult{
-		Status:   Unhealthy,
+		Status: Unhealthy,
 		Target: t,
 	}
 


### PR DESCRIPTION
This PR add support for server-side mTLS (go docs refer to this as ["TLS Client Authentication"](https://golang.org/pkg/crypto/tls/#ClientAuthType)). 
I will add information about the changes to the wiki if this gets merged.
Comments welcome, I'm not sure if `client_auth` keys are ok, but I prefer shorter keys than those used is tls.ClientAuthType. 
Default behavior is still to not require client certificates, so this shouldn't break compatibility.
