### PR TITLE
Skip RRSIG records in response.

### DIFF
--- a/src/discovery/srv.go
+++ b/src/discovery/srv.go
@@ -75,6 +75,10 @@ func srvFetch(cfg config.DiscoveryConfig) (*[]core.Backend, error) {
 	for _, ans := range r.Answer {
 		record, ok := ans.(*dns.SRV)
 		if !ok {
+			// RRSIG is allowed because DNSSEC could be enabled.
+			if _, ok := ans.(*dns.RRSIG); ok {
+				continue
+			}
 			return nil, errors.New("Non-SRV record in SRV answer")
 		}
 

--- a/src/discovery/srv.go
+++ b/src/discovery/srv.go
@@ -153,12 +153,15 @@ func srvIPLookup(cfg config.DiscoveryConfig, pattern string, typ uint16) (string
 		return "", nil
 	}
 
-	switch ans := resp.Answer[0].(type) {
-	case *dns.A:
-		return ans.A.String(), nil
-	case *dns.AAAA:
-		return fmt.Sprintf("[%s]", ans.AAAA.String()), nil
-	default:
-		return "", nil
+	for _, answer := range resp.Answer {
+		switch ans := answer.(type) {
+		case *dns.A:
+			return ans.A.String(), nil
+		case *dns.AAAA:
+			return fmt.Sprintf("[%s]", ans.AAAA.String()), nil
+		default:
+			continue
+		}
 	}
+	return "", nil
 }


### PR DESCRIPTION
Fixes #327.

Without this change a domain that as DNSSEC enabled resulted in the following output:

```
{"level":"info","msg":"Fetching 1.1.1.1:53 _api._tcp.k8s.example.net.","name":"srvFetch","time":"2022-02-27T12:30:28Z"}
{"level":"debug","msg":"Fetching 1.1.1.1:53 A/AAAA node1.example.net.","name":"srvFetch","time":"2022-02-27T12:30:28Z"}
{"level":"warning","msg":"No IP found for node1.example.net., skipping...","name":"srvFetch","time":"2022-02-27T12:30:28Z"}
{"level":"error","msg":"srv error Non-SRV record in SRV answer retrying in 2s","name":"discovery","time":"2022-02-27T12:30:28Z"}
{"level":"info","msg":"Applying failpolicy keeplast","name":"discovery","time":"2022-02-27T12:30:28Z"}
```

With this change the result is:

```
{"level":"debug","msg":"Fetching 1.1.1.1:53 A/AAAA node1.example.net.","name":"srvFetch","time":"2022-02-27T07:27:35-05:00"}
{"level":"debug","msg":"Initial check ping for {X.X.X.X 6443}","name":"healthcheck/worker","time":"2022-02-27T07:27:42-05:00"}
{"level":"debug","msg":"Got check result ping: {{X.X.X.X 6443} 2}","name":"healthcheck/worker","time":"2022-02-27T07:27:42-05:00"}
{"level":"info","msg":"Sending to scheduler: {{X.X.X.X 6443} 2}","name":"healthcheck/worker","time":"2022-02-27T07:27:42-05:00"}

```